### PR TITLE
Editor: horizontal resize grip

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -131,6 +131,10 @@
     "message": "Selection only",
     "description": "Style editor's 'highglight' drop-down list option: highlight the occurrences of currently selected text"
   },
+  "cm_resizeGripHint": {
+    "message": "Double-click to maximize/restore the height",
+    "description": "Tooltip for the resize grip in style editor"
+  },
   "genericDisabledLabel": {
     "message": "Disabled",
     "description": "Used in various lists/options to indicate that something is disabled"

--- a/edit.html
+++ b/edit.html
@@ -681,6 +681,9 @@
 		<template data-id="regexpTestPartial">
 			<a target="_blank" href="https://github.com/stylish-userstyles/stylish/wiki/Applying-styles-to-specific-sites#advanced-matching-with-regular-expressions"><svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg></a>
 		</template>
+		<template data-id="resizeGrip">
+			<div class="resize-grip" i18n-title="cm_resizeGripHint"></div>
+		</template>
 	</head>
 
 	<body id="stylus-edit">

--- a/edit.html
+++ b/edit.html
@@ -192,7 +192,13 @@
 				background: none;
 			}
 			.CodeMirror-vscrollbar {
-				margin-bottom: 8px; /* make space for resize-grip */
+				margin-bottom: 7px; /* make space for resize-grip */
+			}
+			.CodeMirror-hscrollbar {
+		  		bottom: 7px; /* make space for resize-grip */
+			}
+			.CodeMirror-scrollbar-filler {
+				bottom: 7px; /* make space for resize-grip */
 			}
 			.CodeMirror-dialog {
 				-webkit-animation: highlight 3s ease-out;
@@ -242,14 +248,29 @@
 			.resize-grip {
 				position: absolute;
 				display: block;
-				width: 8px;
-				height: 8px;
-				content: " ";
+				height: 6px;
+				content: "";
+				left: 0;
 				right: 0;
 				bottom: 0;
 				z-index: 99;
 				cursor: n-resize;
-				background: linear-gradient(-45deg, transparent 2px, rgba(0,0,0,0.5) 2px, transparent 3px, transparent 4.5px, rgba(0,0,0,0.5) 5px, transparent 5.5px);
+				background-color: inherit;
+				border-top-width: 1px;
+				border-top-style: solid;
+				border-top-color: inherit;
+			}
+			.resize-grip:after {
+				content: "";
+				bottom: 2px;
+				left: 0;
+				right: 0;
+				margin: 0 8px;
+				display: block;
+				position: absolute;
+				border-top-width: 2px;
+				border-top-style: dotted;
+				border-top-color: inherit;
 			}
 			/* applies-to */
 			.applies-to {

--- a/edit.html
+++ b/edit.html
@@ -253,7 +253,7 @@
 				left: 0;
 				right: 0;
 				bottom: 0;
-				z-index: 99;
+				z-index: 9;
 				cursor: n-resize;
 				background-color: inherit;
 				border-top-width: 1px;

--- a/edit.js
+++ b/edit.js
@@ -390,20 +390,6 @@ function setupCodeMirror(textarea, index) {
 			document.body.style.cursor = '';
 		});
 	});
-	// resizeGrip has enough space when scrollbars.horiz is visible
-	if (cm.display.scrollbars.horiz.style.display != "") {
-		cm.display.scrollbars.vert.style.marginBottom = "0";
-	}
-	// resizeGrip space adjustment in case a long line was entered/deleted by a user
-	new MutationObserver(function(mutations) {
-		var hScrollbar = mutations[0].target;
-		var hScrollbarVisible = hScrollbar.style.display != "";
-		var vScrollbar = hScrollbar.parentNode.CodeMirror.display.scrollbars.vert;
-		vScrollbar.style.marginBottom = hScrollbarVisible ? "0" : "";
-	}).observe(cm.display.scrollbars.horiz, {
-		attributes: true,
-		attributeFilter: ["style"]
-	});
 
 	editors.splice(index || editors.length, 0, cm);
 	return cm;

--- a/edit.js
+++ b/edit.js
@@ -343,53 +343,60 @@ function acmeEventListener(event) {
 
 // replace given textarea with the CodeMirror editor
 function setupCodeMirror(textarea, index) {
-	var cm = CodeMirror.fromTextArea(textarea, {lint: null});
+	const cm = CodeMirror.fromTextArea(textarea, {lint: null});
+	const wrapper = cm.display.wrapper;
 
-	cm.on("change", indicateCodeChange);
+	cm.on('change', indicateCodeChange);
 	if (prefs.get('editor.autocompleteOnTyping')) {
 		cm.on('change', autocompleteOnTyping);
 		cm.on('pick', autocompletePicked);
 	}
-	cm.on("blur", function(cm) {
+	cm.on('blur', () => {
 		editors.lastActive = cm;
 		hotkeyRerouter.setState(true);
-		setTimeout(function() {
-			var cm = editors.lastActive;
-			var childFocused = cm.display.wrapper.contains(document.activeElement);
-			cm.display.wrapper.classList.toggle("CodeMirror-active", childFocused);
-		}, 0);
+		setTimeout(() => {
+			wrapper.classList.toggle('CodeMirror-active', wrapper.contains(document.activeElement));
+		});
 	});
-	cm.on("focus", function() {
+	cm.on('focus', () => {
 		hotkeyRerouter.setState(false);
-		cm.display.wrapper.classList.add("CodeMirror-active");
+		wrapper.classList.add('CodeMirror-active');
 	});
 	cm.on('mousedown', (cm, event) => toggleContextMenuDelete.call(cm, event));
 
-	var resizeGrip = cm.display.wrapper.appendChild(document.createElement("div"));
-	resizeGrip.className = "resize-grip";
-	resizeGrip.addEventListener("mousedown", function(e) {
-		e.preventDefault();
-		var cm = e.target.parentNode.CodeMirror;
-		var minHeight = cm.defaultTextHeight()
+	let lastClickTime = 0;
+	const resizeGrip = wrapper.appendChild(template.resizeGrip.cloneNode(true));
+	resizeGrip.onmousedown = event => {
+		if (event.button != 0) {
+			return;
+		}
+		event.preventDefault();
+		if (Date.now() - lastClickTime < 500) {
+			lastClickTime = 0;
+			toggleSectionHeight(cm);
+			return;
+		}
+		lastClickTime = Date.now();
+		const minHeight = cm.defaultTextHeight()
 			+ cm.display.lineDiv.offsetParent.offsetTop /* .CodeMirror-lines padding */
-			+ cm.display.wrapper.offsetHeight - cm.display.wrapper.clientHeight /* borders */;
-		cm.display.wrapper.style.pointerEvents = 'none';
+			+ wrapper.offsetHeight - wrapper.clientHeight /* borders */;
+		wrapper.style.pointerEvents = 'none';
 		document.body.style.cursor = 's-resize';
 		function resize(e) {
-			const cmPageY = cm.display.wrapper.getBoundingClientRect().top + window.scrollY;
+			const cmPageY = wrapper.getBoundingClientRect().top + window.scrollY;
 			const height = Math.max(minHeight, e.pageY - cmPageY);
-			if (height != cm.display.wrapper.clientHeight) {
+			if (height != wrapper.clientHeight) {
 				cm.setSize(null, height);
 			}
 		}
-		document.addEventListener("mousemove", resize);
-		document.addEventListener("mouseup", function resizeStop() {
-			document.removeEventListener("mouseup", resizeStop);
-			document.removeEventListener("mousemove", resize);
-			cm.display.wrapper.style.pointerEvents = '';
+		document.addEventListener('mousemove', resize);
+		document.addEventListener('mouseup', function resizeStop() {
+			document.removeEventListener('mouseup', resizeStop);
+			document.removeEventListener('mousemove', resize);
+			wrapper.style.pointerEvents = '';
 			document.body.style.cursor = '';
 		});
-	});
+	};
 
 	editors.splice(index || editors.length, 0, cm);
 	return cm;
@@ -870,6 +877,27 @@ function jumpToLine(cm) {
 function toggleStyle() {
 	$('#enabled').checked = !$('#enabled').checked;
 	save();
+}
+
+function toggleSectionHeight(cm) {
+	if (cm.state.toggleHeightSaved) {
+		// restore previous size
+		cm.setSize(null, cm.state.toggleHeightSaved);
+		cm.state.toggleHeightSaved = 0;
+	} else {
+		// maximize
+		const wrapper = cm.display.wrapper;
+		const allBounds = $('#sections').getBoundingClientRect();
+		const pageExtrasHeight = allBounds.top + window.scrollY +
+			parseFloat(getComputedStyle($('#sections')).paddingBottom);
+		const sectionExtrasHeight = cm.getSection().clientHeight - wrapper.offsetHeight;
+		cm.state.toggleHeightSaved = wrapper.clientHeight;
+		cm.setSize(null, window.innerHeight - sectionExtrasHeight - pageExtrasHeight);
+		const bounds = cm.getSection().getBoundingClientRect();
+		if (bounds.top < 0 || bounds.bottom > window.innerHeight) {
+			window.scrollBy(0, bounds.top);
+		}
+	}
 }
 
 function autocompleteOnTyping(cm, info, debounced) {


### PR DESCRIPTION
I want to make the resize grip more accessible. 
A better default style is welcome if you have ideas.

![clip289-fs8](https://user-images.githubusercontent.com/1310400/27597592-796b3e5a-5b6b-11e7-8cc0-d1137402d0da.png)

And maybe do something upon double-click on the grip? 
Like autosizing to code height or window height or ...?

@narcolepticinsomniac, @schomery, PTAL.