### PR TITLE
manage: add inverted filters (disabled, external)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -349,9 +349,17 @@
     "message": "Only enabled styles",
     "description": "Checkbox to show only enabled styles"
   },
+  "manageOnlyDisabled": {
+    "message": "Only disabled styles",
+    "description": "Checkbox to show only disabled styles"
+  },
   "manageOnlyLocal": {
     "message": "Only locally created styles",
     "description": "Checkbox to show only locally created styles i.e. non-updatable"
+  },
+  "manageOnlyExternal": {
+    "message": "Only external styles",
+    "description": "Checkbox to show only externally installed styles i.e. updatable"
   },
   "manageOnlyLocalTooltip": {
     "message": "(the styles not installed through a userstyles.org page)",

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -17,6 +17,8 @@ var prefs = new function Prefs() {
 
     'manage.onlyEnabled': false,    // display only enabled styles
     'manage.onlyLocal': false,      // display only styles created locally
+    'manage.onlyEnabled.invert': false, // display only disabled styles
+    'manage.onlyLocal.invert': false,   // display only externally installed styles
     'manage.newUI': true,           // use the new compact layout
     'manage.newUI.favicons': false, // show favicons for the sites in applies-to
     'manage.newUI.faviconsGray': true, // gray out favicons

--- a/manage.html
+++ b/manage.html
@@ -143,13 +143,19 @@
       <input id="manage.onlyEnabled" type="checkbox"
              data-filter=".enabled"
              data-filter-hide=".disabled">
-      <span i18n-text="manageOnlyEnabled"></span>
+      <select id="manage.onlyEnabled.invert">
+        <option i18n-text="manageOnlyEnabled" value="false"></option>
+        <option i18n-text="manageOnlyDisabled" value="true"></option>
+      </select>
     </label>
     <label>
       <input id="manage.onlyLocal" type="checkbox"
              data-filter=":not(.updatable)"
              data-filter-hide=".updatable">
-      <span i18n-text="manageOnlyLocal" i18n-title="manageOnlyLocalTooltip"></span>
+      <select id="manage.onlyLocal.invert" i18n-title="manageOnlyLocalTooltip">
+        <option i18n-text="manageOnlyLocal" value="false"></option>
+        <option i18n-text="manageOnlyExternal" value="true"></option>
+      </select>
     </label>
     <label id="onlyUpdates" class="hidden">
       <input type="checkbox"

--- a/manage/filters.js
+++ b/manage/filters.js
@@ -12,6 +12,38 @@ const filtersSelector = {
 onDOMready().then(onBackgroundReady).then(() => {
   $('#search').oninput = searchStyles;
 
+  $$('select[id$=".invert"]').forEach(el => {
+    const slave = $('#' + el.id.replace('.invert', ''));
+    const slaveData = slave.dataset;
+    const valueMap = new Map([
+      [false, slaveData.filter],
+      [true, slaveData.filterHide],
+    ]);
+    //
+    // enable slave control when user switches the value
+    el.oninput = () => {
+      if (!slave.checked) {
+        // oninput occurs before onchange
+        setTimeout(() => {
+          if (!slave.checked) {
+            slave.checked = true;
+            slave.dispatchEvent(new Event('change', {bubbles: true}));
+          }
+        });
+      }
+    };
+    // swap slave control's filtering rules
+    el.onchange = event => {
+      const value = el.value === 'true';
+      const filter = valueMap.get(value);
+      if (slaveData.filter !== filter) {
+        slaveData.filter = filter;
+        slaveData.filterHide = valueMap.get(!value);
+        debounce(filterOnChange, 0, event);
+      }
+    };
+  });
+
   $$('[data-filter]').forEach(el => {
     el.onchange = filterOnChange;
     if (el.closest('.hidden')) {

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -544,6 +544,8 @@ fieldset {
   border-width: 1px;
   border-radius: 6px;
   margin: 1em 0;
+  min-width: 0;
+  max-width: 250px;
 }
 
 fieldset > *:not(legend) {
@@ -572,6 +574,8 @@ fieldset > *:not(legend) {
 #manage\.onlyEnabled\.invert,
 #manage\.onlyLocal\.invert {
   border: none;
+  max-width: calc(100% - 2em);
+  background-color: transparent;
 }
 
 #search {

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -569,6 +569,11 @@ fieldset > *:not(legend) {
   content: ": ";
 }
 
+#manage\.onlyEnabled\.invert,
+#manage\.onlyLocal\.invert {
+  border: none;
+}
+
 #search {
   width: calc(100% - 4px);
   margin: 0.25rem 4px 0;

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -19,6 +19,7 @@ const newUI = {
   },
 };
 newUI.renderClass();
+usePrefsDuringPageLoad();
 
 const TARGET_TYPES = ['domains', 'urls', 'urlPrefixes', 'regexps'];
 const GET_FAVICON_URL = 'https://www.google.com/s2/favicons?domain=';
@@ -501,4 +502,25 @@ function switchUI({styleOnly} = {}) {
 
 function rememberScrollPosition() {
   history.replaceState({scrollY: window.scrollY}, document.title);
+}
+
+
+function usePrefsDuringPageLoad() {
+  const observer = new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        // [naively] assuming each element of addedNodes is a childless element
+        const prefValue = node.id ? prefs.readOnlyValues[node.id] : undefined;
+        if (prefValue !== undefined) {
+          if (node.type === 'checkbox') {
+            node.checked = prefValue;
+          } else {
+            node.value = prefValue;
+          }
+        }
+      }
+    }
+  });
+  observer.observe(document, {subtree: true, childList: true});
+  onDOMready().then(() => observer.disconnect());
 }

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -507,6 +507,7 @@ function rememberScrollPosition() {
 
 function usePrefsDuringPageLoad() {
   const observer = new MutationObserver(mutations => {
+    const adjustedNodes = [];
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {
         // [naively] assuming each element of addedNodes is a childless element
@@ -517,10 +518,23 @@ function usePrefsDuringPageLoad() {
           } else {
             node.value = prefValue;
           }
+          if (node.adjustWidth) {
+            adjustedNodes.push(node);
+          }
         }
       }
     }
+    if (adjustedNodes.length) {
+      observer.disconnect();
+      for (const node of adjustedNodes) {
+        node.adjustWidth();
+      }
+      startObserver();
+    }
   });
-  observer.observe(document, {subtree: true, childList: true});
+  function startObserver() {
+    observer.observe(document, {subtree: true, childList: true});
+  }
+  startObserver();
   onDOMready().then(() => observer.disconnect());
 }


### PR DESCRIPTION
The checkbox filters can be inverted now.
A bit unusual, though, since the entire label is a selector.

I've tried and discarded a couple of alternative solutions, and this one seems the least cluttered and most self-evident to me. Not sure about convenience as I almost never use the filters.

Please test: [invert-filters.zip](https://github.com/openstyles/stylus/archive/invert-filters.zip).

![clip340-fs8](https://user-images.githubusercontent.com/1310400/29533127-296bf6f0-86b9-11e7-8c23-744cf74e16c1.png)
