### PR TITLE
URL-matching mode in manager's search and popup's manage button

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -425,6 +425,10 @@
     "message": "More Options",
     "description": "Subheading for options section on manage page."
   },
+  "popupManageTooltip": {
+    "message": "Shift-click or right-click opens manager with styles applicable for current site",
+    "description": "Tooltip for the 'Manage' button in the popup."
+  },
   "popupStylesFirst": {
     "message": "Styles before commands",
     "description": "Label for the checkbox controlling section order in the popup."
@@ -455,6 +459,10 @@
   },
   "searchStyles": {
     "message": "Search contents",
+    "description": "Label for the search filter textbox on the Manage styles page"
+  },
+  "searchStylesTooltip": {
+    "message": "To show styles for a URL, prefix it with 'url:'\nFor example, url:https://github.com/openstyles/stylus",
     "description": "Label for the search filter textbox on the Manage styles page"
   },
   "sectionAdd": {

--- a/manage.html
+++ b/manage.html
@@ -164,6 +164,7 @@
       <span i18n-text="manageOnlyUpdates"></span>
     </label>
     <input id="search" type="search" i18n-placeholder="searchStyles" spellcheck="false"
+           i18n-title="searchStylesTooltip"
            data-filter=":not(.not-matching)"
            data-filter-hide=".not-matching">
   </fieldset>

--- a/popup.html
+++ b/popup.html
@@ -99,7 +99,7 @@
     <!-- Actions -->
     <div id="popup-options">
       <button id="popup-manage-button" i18n-text="openManage"
-              data-href="manage.html" i18n-title="optionsOpenManager"></button>
+              data-href="manage.html" i18n-title="popupManageTooltip"></button>
       <button id="popup-options-button" i18n-text="openOptionsPopup"></button>
       <button id="popup-shortcuts-button" class="chromium-only"
               i18n-text="shortcuts"

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -89,7 +89,11 @@ function initPopup(url) {
   setupLivePrefs();
 
   $('#find-styles-link').onclick = handleEvent.openURLandHide;
-  $('#popup-manage-button').onclick = handleEvent.openURLandHide;
+  Object.assign($('#popup-manage-button'), {
+    onclick: handleEvent.openManager,
+    onmouseup: handleEvent.openManager,
+    oncontextmenu: handleEvent.openManager,
+  });
 
   $('#popup-options-button').onclick = () => {
     chrome.runtime.openOptionsPage();
@@ -380,6 +384,16 @@ Object.assign(handleEvent, {
     event.preventDefault();
     openURL({url: this.href || this.dataset.href})
       .then(window.close);
+  },
+
+  openManager(event) {
+    event.preventDefault();
+    if (!this.eventHandled) {
+      this.eventHandled = true;
+      this.dataset.href += event.shiftKey || event.button === 2 ?
+        '?url=' + encodeURIComponent(tabURL) : '';
+      handleEvent.openURLandHide.call(this, event);
+    }
   },
 });
 


### PR DESCRIPTION
Basically like Tampermonkey's user-configurable browser shortcut to "Open the dashboard with the current tab's URL used as filter".

@narcolepticinsomniac, @Mottie, @schomery,
please test it: [manage-site-styles.zip](https://github.com/openstyles/stylus/archive/manage-site-styles.zip).

* in manager use search query like `url:https://github.com/openstyles/stylus`
* in popup `shift-click` or `right-click` on `manage` button opens it in a new tab and applies the filter

P.S. The PR is rather trivial and doesn't introduce conflicts with other pending PRs.
