### PR TITLE
inform when dysfunctional due to FF options

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -135,6 +135,14 @@
     "message": "Double-click to maximize/restore the height",
     "description": "Tooltip for the resize grip in style editor"
   },
+  "dysfunctional": {
+    "message": "Stylus cannot function because Firefox is either in private mode or is applying its website cookies policy to IndexedDB storage used by Stylus, which erroneously marks the secure moz-extension:// origin as insecure even though WebExtensions aren't websites and Stylus doesn't use cookies.\n\n1. Open Firefox options\n2. Go to 'Privacy & Security'\n3. Set 'History' mode to 'Use custom settings'\n4. Click 'Exceptions'\n5. Paste our manifest URL and click 'Allow'\n6. Click 'Save settings'\n7. Uncheck 'Always use private browsing mode'\n\nThe actual manifest URL is shown below.\nYou can also find it on about:debugging page.",
+    "description": "Displayed in Firefox when its settings make Stylus dysfunctional"
+  },
+  "dysfunctionalBackgroundConnection": {
+    "message": "Cannot function properly because of a known bug in this version of Firefox: chrome.extension.getBackgroundPage() doesn't return a valid result",
+    "description": "Displayed in style manager when unable to connect to the background page"
+  },
   "genericDisabledLabel": {
     "message": "Disabled",
     "description": "Used in various lists/options to indicate that something is disabled"

--- a/background/background.js
+++ b/background/background.js
@@ -5,10 +5,8 @@
 var browserCommands, contextMenus;
 
 // *************************************************************************
-// preload the DB and report errors
-dbExec().catch((...args) => {
-  args.forEach(arg => 'message' in arg && console.error(arg.message));
-});
+// preload the DB
+tryCatch(getStyles);
 
 // *************************************************************************
 // register all listeners

--- a/background/storage.js
+++ b/background/storage.js
@@ -59,7 +59,7 @@ function dbExec(method, data) {
         }
       },
       onerror(event) {
-        console.warn(event.target.errorCode);
+        console.warn(event.target.error || event.target.errorCode);
         reject(event);
       },
       onupgradeneeded(event) {

--- a/background/update.js
+++ b/background/update.js
@@ -18,7 +18,7 @@ var updater = {
   ERROR_MD5: 'error: MD5 is invalid',
   ERROR_JSON: 'error: JSON is invalid',
 
-  lastUpdateTime: parseInt(localStorage.lastUpdateTime) || Date.now(),
+  lastUpdateTime: parseInt(tryCatch(() => localStorage.lastUpdateTime)) || Date.now(),
 
   checkAllStyles({observer = () => {}, save = true, ignoreDigest} = {}) {
     updater.resetInterval();

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -74,6 +74,9 @@ var prefs = new function Prefs() {
     specific: new Map(),
   };
 
+  // FF may think localStorage is a cookie or that it's not secure
+  const localStorage = tryCatch(() => localStorage) ? window.localStorage : {};
+
   // coalesce multiple pref changes in broadcast
   let broadcastPrefs = {};
 
@@ -203,7 +206,7 @@ var prefs = new function Prefs() {
       }
     };
 
-    getSync().get('settings', ({settings}) => importFromSync(settings));
+    getSync().get('settings', ({settings} = {}) => importFromSync(settings));
 
     chrome.storage.onChanged.addListener((changes, area) => {
       if (area === 'sync' && 'settings' in changes) {

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -35,7 +35,8 @@ Promise.all([
 });
 
 if (FIREFOX) {
-  // TODO: remove when this bug is fixed in FF
+  // TODO: remove when these bugs are fixed in FF
+  dieOnNullBackground();
   retranslateCSS({
     '.disabled h2::after':
       '__MSG_genericDisabledLabel__',
@@ -537,4 +538,25 @@ function usePrefsDuringPageLoad() {
   }
   startObserver();
   onDOMready().then(() => observer.disconnect());
+}
+
+
+function dieOnNullBackground() {
+  if (BG) {
+    return;
+  }
+  chrome.runtime.sendMessage({method: 'healthCheck'}, health => {
+    if (health && !chrome.extension.getBackgroundPage()) {
+      onDOMready().then(() => {
+        chrome.runtime.sendMessage({method: 'getStyles'}, showStyles);
+        messageBox({
+          title: 'Stylus',
+          className: 'danger center',
+          contents: t('dysfunctionalBackgroundConnection'),
+          onshow: () => $('#message-box-close-icon').remove(),
+        });
+        document.documentElement.style.pointerEvents = 'none';
+      });
+    }
+  });
 }

--- a/msgbox/dysfunctional.css
+++ b/msgbox/dysfunctional.css
@@ -1,0 +1,21 @@
+html {
+  height: 100vh;
+  min-height: 450px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: pre-wrap;
+  background-color: #555;
+  box-sizing: border-box;
+  border: 2vw solid black;
+}
+
+body {
+  margin: 2em;
+  color: white;
+  max-width: 600px;
+}
+
+div {
+  color: antiquewhite;
+}

--- a/msgbox/dysfunctional.html
+++ b/msgbox/dysfunctional.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html id="stylus">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="dysfunctional.css">
+</head>
+<body>
+  <script src="dysfunctional.js"></script>
+</body>

--- a/msgbox/dysfunctional.js
+++ b/msgbox/dysfunctional.js
@@ -1,0 +1,6 @@
+'use strict';
+
+document.body.textContent =
+  chrome.i18n.getMessage('dysfunctional');
+document.body.appendChild(document.createElement('div')).textContent =
+  chrome.runtime.getURL('manifest.json');


### PR DESCRIPTION
IndexedDB being blocked by Firefox is detected and a warning page is displayed instead of the actual contents.

```
Stylus cannot function because Firefox applies its website cookies policy to 
unrelated storages used by Stylus such as IndexedDB and localStorage, 
erroneously marking the secure internal moz-extension:// origin as insecure even 
though WebExtensions aren't websites and Stylus doesn't use cookies. 

You can add an exception for Stylus: 
1. open Firefox options 
2. go to Privacy & Security 
3. set History mode to 'Use custom settings' 
4. click 'Exceptions' 
5. paste our manifest URL and click 'Allow'
6. click 'Save settings'.

The actual manifest URL is shown below, also on about:debugging page.
moz-extension://006bd111-b39c-4beb-99ed-cb36302c9607/manifest.json
```

Please review the text, @narcolepticinsomniac.

![clip349-fs8](https://user-images.githubusercontent.com/1310400/29669414-0d467736-88ec-11e7-9000-c8dea5cdd143.png)