### PR TITLE
apply: replace spread operator

### DIFF
--- a/content/apply.js
+++ b/content/apply.js
@@ -277,7 +277,7 @@ function replaceAll(newStyles) {
   oldStyles.forEach(el => (el.id += '-ghost'));
   styleElements.clear();
   disabledElements.clear();
-  [...retiredStyleTimers.values()].forEach(clearTimeout);
+  Array.prototype.slice.call(retiredStyleTimers.values()).forEach(clearTimeout);
   retiredStyleTimers.clear();
   applyStyles(newStyles);
   oldStyles.forEach(el => el.remove());


### PR DESCRIPTION
Given the comment at the top of the apply.js file

> // Not using some slow features of ES6,... spread,...

This PR replaces the spread operator in the `replaceAll` function.

