### PR TITLE
Lint: Add -webkit-sticky support to CSSLint

### DIFF
--- a/vendor-overwrites/csslint/csslint-worker.js
+++ b/vendor-overwrites/csslint/csslint-worker.js
@@ -3715,7 +3715,7 @@ var Properties = module.exports = {
     "pitch-range"                   : 1,
     "play-during"                   : 1,
     "pointer-events"                : "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all",
-    "position"                      : "static | relative | absolute | fixed | sticky",
+    "position"                      : "static | relative | absolute | fixed | sticky | -webkit-sticky",
     "presentation-level"            : 1,
     "punctuation-trim"              : 1,
 


### PR DESCRIPTION
Safari only supports the sticky position with a `-webkit` prefix ([ref 1](http://caniuse.com/#feat=css-sticky) &amp; [ref 2](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Browser_compatibility)).