### PR TITLE
Fix appearance of non-disabled elements

### DIFF
--- a/manage/manage.css
+++ b/manage/manage.css
@@ -6,7 +6,7 @@ body {
   height: 100%;
 }
 
-a {
+a, .disabled a:hover {
   color: #000;
   transition: color .5s;
   text-decoration-skip: ink;
@@ -208,8 +208,10 @@ summary {
   color: white;
 }
 
-.disabled {
+.disabled h2 .style-name-link,
+.disabled .applies-to {
   opacity: 0.5;
+  font-weight: normal;
 }
 
 .disabled .disable {
@@ -230,11 +232,6 @@ summary {
 
 .newUI .disabled {
   opacity: 1;
-}
-
-.newUI .disabled .style-name,
-.newUI .disabled .applies-to {
-  opacity: .5;
 }
 
 .newUI .entry {
@@ -279,7 +276,7 @@ summary {
   pointer-events: none;
 }
 
-.newUI .style-name:hover .style-name-link {
+.newUI .entry.enabled .style-name:hover .style-name-link {
   color: hsla(180, 100%, 15%, 1);
 }
 


### PR DESCRIPTION
Fixed:

* The all action buttons and external link (old UI), and checkbox (new UI) are now fully opaque when disabled.
* Disabled tag is fully opaque.
* <del>Added `#fee` background color to disabled entries to better visualize disabled entries.</del>