### PR TITLE
Popup overflow

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -176,9 +176,9 @@
     </div>
   </div>
 
-  <aside id="hotkey-info" i18n-title="popupHotkeysTooltip"></aside>
-
-  <div id="installed"></div>
+  <div id="installed">
+    <aside id="hotkey-info" i18n-title="popupHotkeysTooltip"></aside>
+  </div>
 
   <div class="actions">
     <div id="disable-all-wrapper">

--- a/popup/hotkeys.js
+++ b/popup/hotkeys.js
@@ -160,10 +160,9 @@ var hotkeys = (() => {
       if (!container.firstElementChild) {
         buildElement();
       }
-      const height = 4 +
+      const height = 3 +
         container.firstElementChild.scrollHeight +
-        container.lastElementChild.scrollHeight +
-        parseFloat(getComputedStyle(container.lastElementChild).paddingBottom);
+        container.lastElementChild.scrollHeight;
       if (height > document.body.clientHeight) {
         document.body.style.height = height + 'px';
       }
@@ -202,20 +201,6 @@ var hotkeys = (() => {
     if (debounced !== true) {
       debounce(adjustInfoPosition, 100, true);
       return;
-    }
-    const style = $('#hotkey-info').style;
-    const scroller = document.scrollingElement;
-    if (installed.scrollHeight > installed.clientHeight ||
-        scroller.scrollHeight > scroller.innerHeight) {
-      const entryRight = installed.firstElementChild.getBoundingClientRect().right;
-      const right = window.innerWidth - entryRight;
-      if (parseFloat(style.right) !== right) {
-        style.setProperty('right', right + 'px', 'important');
-      }
-    }
-    const bottom = installed.getBoundingClientRect().bottom + window.scrollY;
-    if (parseFloat(style.height) !== bottom) {
-      style.setProperty('height', bottom + 'px', 'important');
     }
   }
 })();

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -9,6 +9,7 @@
 
 html, body {
   height: min-content;
+  max-height: 600px;
 }
 
 body {
@@ -144,6 +145,7 @@ body.blocked > DIV {
   max-height: 445px;
   overflow-y: auto;
   counter-reset: style-number;
+  position: relative;
 }
 
 #installed.disabled .style-name {
@@ -555,7 +557,9 @@ body.blocked .actions > .main-controls {
 }
 
 #hotkey-info[data-active] {
+  position: fixed;
   left: 6ex;
+  bottom: unset;
   width: auto;
   cursor: auto;
   display: flex;


### PR DESCRIPTION
Moving `#hotkey-info` inside of `#installed` still makes the most sense to me. With a few adjustments to the CSS, we can lose the js calc for its height altogether. I also don't see a reason for it to be the entire height of the popup if the popup is already tall enough to accommodate it, so I adjusted that as well. I don't think a wrapper would be a huge deal, but I don't see a need for one anyway.

I suppose there may be scenarios I'm not accounting for, but everything appears to look right and work correctly with these changes. Goes without saying, whenever I modify js it should be scrutinized. In this case I wouldn't be surprised if I left some code made irrelevant by what I removed.