### PR TITLE
add a wiki link, shorten the USO link, use https everywhere

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -493,6 +493,18 @@
     "message": "License",
     "description": "Label for the license"
   },
+  "linkGetStyles": {
+    "message": "Get styles",
+    "description": "Help link text on the manage page e.g. https://userstyles.org"
+  },
+  "linkGetHelp": {
+    "message": "Get help",
+    "description": "Homepage link text on the manage page e.g. https://add0n.com/stylus.html#features with chat/FAQ/intro/info"
+  },
+  "linkStylusWiki": {
+    "message": "Wiki",
+    "description": "Wiki link text on the manage page e.g. https://github.com/openstyles/stylus/wiki"
+  },
   "linterConfigPopupTitle": {
     "message": "Set $linter$ rules configuration",
     "description": "Stylelint or CSSLint popup header",
@@ -619,10 +631,6 @@
   "manageMaxTargets": {
     "message": "Number of applies-to items",
     "description": "Label for the numeric input box to limit max number of applies-to targets in the new UI on manage page"
-  },
-  "manageText": {
-    "message": "<a href='https://userstyles.org'>Get styles on userstyles.org</a> | <a href='http://add0n.com/stylus.html'>Get help</a>",
-    "description": "Help text on the manage page"
   },
   "manageTitle": {
     "message": "Stylus",

--- a/manage.html
+++ b/manage.html
@@ -337,7 +337,11 @@
     </p>
   </details>
 
-  <p id="manage-text" i18n-html="manageText"></p>
+  <p id="manage-text">
+    <span><a href="https://userstyles.org" target="_blank" i18n-text="linkGetStyles"></a></span>
+    <span><a href="https://add0n.com/stylus.html#features" target="_blank" i18n-text="linkGetHelp"></a></span>
+    <span><a href="https://github.com/openstyles/stylus/wiki" target="_blank" i18n-text="linkStylusWiki"></a></span>
+  </p>
 
 </div>
 

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -411,6 +411,15 @@ select {
   margin: -2px 1ex 0 0;
 }
 
+#manage-text {
+  display: flex;
+}
+
+#manage-text > :not(:last-child):after {
+  content: "|";
+  margin: 0 .5em;
+}
+
 .newUI .entry .svg-icon.checked,
 .newUI .entry:hover .svg-icon.checked {
   fill: #000;

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "version": "1.1.8",
   "minimum_chrome_version": "49",
   "description": "__MSG_description__",
-  "homepage_url": "http://add0n.com/stylus.html",
+  "homepage_url": "https://add0n.com/stylus.html",
   "manifest_version": 2,
   "icons": {
     "16": "/images/icon/16.png",


### PR DESCRIPTION
* `https` in manifest.json's homepage URL
* `Get styles` instead of `Get styles on userstyles.org`
* `Get help` points to https://add0n.com/stylus.html#features to skip the annoying ad
* `Wiki` points to https://github.com/openstyles/stylus/wiki
* All three labels are separate plain-text messages so now we have one html message left, we'll deal with that later

![clip420-fs8](https://user-images.githubusercontent.com/1310400/33921136-e3728b14-dfd2-11e7-8647-e5ab1bf895ca.png)
