### PR TITLE
user cssOrigin: 'user' in insertcss branch

### DIFF
--- a/background/style-via-api.js
+++ b/background/style-via-api.js
@@ -93,6 +93,7 @@ var styleViaAPI = !CHROME && (() => {
             frameId,
             runAt: 'document_start',
             matchAboutBlank: true,
+            cssOrigin: 'user',
           }).catch(onError));
       }
       Object.defineProperty(frameStyles, 'url', {value: url, configurable: true});


### PR DESCRIPTION
Note: This PR targets the `insertcss` branch.

Added the[`cssOrigin: 'user'`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/insertCSS#Parameters) option, which inserts the CSS as a `user` instead of a `author` stylesheet, which is very beneficial when targeting pages that have `!important` rules. Also see [here](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#Cascading_order) for more details about CSS cascading.