### PR TITLE
Minor fixes

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -269,15 +269,13 @@
           <button id="beautify" i18n-text="styleBeautify"></button>
           <a href="manage.html" tabindex="-1"><button id="cancel-button" i18n-text="styleCancelEditLabel"></button></a>
         </div>
-        <div id="mozilla-format-container">
-          <h2 id="mozilla-format-heading" i18n-text="styleMozillaFormatHeading">
-            <a id="to-mozilla-help" class="svg-inline-wrapper" href="#">
-              <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
-            </a>
-          </h2>
+        <p id="mozilla-format-container">
           <button id="from-mozilla" i18n-text="importLabel"></button>
           <button id="to-mozilla" i18n-text="exportLabel"></button>
-        </div>
+          <a id="to-mozilla-help" class="svg-inline-wrapper" href="#">
+            <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
+          </a>
+        </p>
       </section>
       <details id="options" data-pref="editor.options.expanded">
         <summary><h2 id="options-heading" i18n-text="optionsHeading"></h2></summary>

--- a/edit.html
+++ b/edit.html
@@ -270,8 +270,8 @@
           <a href="manage.html" tabindex="-1"><button id="cancel-button" i18n-text="styleCancelEditLabel"></button></a>
         </div>
         <div id="mozilla-format-container">
-          <button id="from-mozilla" i18n-text="importLabel"></button>
-          <button id="to-mozilla" i18n-text="exportLabel"></button>
+          <button id="from-mozilla" i18n-title="styleMozillaFormatHeading" i18n-text="importLabel"></button>
+          <button id="to-mozilla" i18n-title="styleMozillaFormatHeading" i18n-text="exportLabel"></button>
           <a id="to-mozilla-help" class="svg-inline-wrapper" href="#">
             <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
           </a>

--- a/edit.html
+++ b/edit.html
@@ -269,13 +269,13 @@
           <button id="beautify" i18n-text="styleBeautify"></button>
           <a href="manage.html" tabindex="-1"><button id="cancel-button" i18n-text="styleCancelEditLabel"></button></a>
         </div>
-        <p id="mozilla-format-container">
+        <div id="mozilla-format-container">
           <button id="from-mozilla" i18n-text="importLabel"></button>
           <button id="to-mozilla" i18n-text="exportLabel"></button>
           <a id="to-mozilla-help" class="svg-inline-wrapper" href="#">
             <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
           </a>
-        </p>
+        </div>
       </section>
       <details id="options" data-pref="editor.options.expanded">
         <summary><h2 id="options-heading" i18n-text="optionsHeading"></h2></summary>

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -81,6 +81,11 @@ label {
   min-height: 1.4rem;
 }
 
+#mozilla-format-container {
+  align-items: center;
+  margin-top: .5rem;
+}
+
 /* basic info */
 #basic-info {
   margin-bottom: 1rem;
@@ -143,7 +148,7 @@ label {
   height: 16px;
 }
 .svg-inline-wrapper {
-  margin-left: .2rem;
+  margin-left: .1rem;
   display: inline-block;
   vertical-align: middle;
 }
@@ -191,7 +196,7 @@ input:invalid {
   align-items: center;
   margin-left: -13px;
   cursor: pointer;
-  margin-top: 8px;
+  margin-top: .8rem;
   margin-bottom: 8px;
 }
 
@@ -208,10 +213,6 @@ input:invalid {
 
 #header summary svg {
   margin-top: -3px;
-}
-
-#actions {
-  margin-bottom: .5rem;
 }
 
 #options:not([open]) + #lint h2 {

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -467,7 +467,7 @@ html:not(.usercss) .applies-to li:last-child .add-applies-to {
 #help-popup {
   top: 3rem;
   right: 3rem;
-  max-width: 50vw;
+  max-width: 26rem;
   position: fixed;
   display: none;
   background-color: white;
@@ -489,6 +489,7 @@ html:not(.usercss) .applies-to li:last-child .add-applies-to {
 }
 #help-popup .title {
   font-weight: bold;
+  font-size: 1rem;
   background-color: rgba(0,0,0,0.05);
   margin: -0.5rem -0.5rem 0.5rem;
   padding: .5rem 32px .5rem .5rem;
@@ -497,6 +498,10 @@ html:not(.usercss) .applies-to li:last-child .add-applies-to {
   max-height: calc(100vh - 8rem);
   overflow-y: auto;
 }
+#help-popup.info .contents {
+  padding: 1.5rem .75rem;
+}
+
 #help-popup .settings {
   min-width: 500px;
   min-height: 200px;

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -516,22 +516,22 @@ function fromMozillaFormat() {
 
 function showSectionHelp(event) {
   event.preventDefault();
-  showHelp(t('styleSectionsTitle'), t('sectionHelp'));
+  showHelp(t('styleSectionsTitle'), t('sectionHelp'), 'info');
 }
 
 function showAppliesToHelp(event) {
   event.preventDefault();
-  showHelp(t('appliesLabel'), t('appliesHelp'));
+  showHelp(t('appliesLabel'), t('appliesHelp'), 'info');
 }
 
 function showToMozillaHelp(event) {
   event.preventDefault();
-  showHelp(t('styleMozillaFormatHeading'), t('styleToMozillaFormatHelp'));
+  showHelp(t('styleMozillaFormatHeading'), t('styleToMozillaFormatHelp'), 'info');
 }
 
-function showHelp(title = '', body) {
+function showHelp(title = '', body, className = '') {
   const div = $('#help-popup');
-  div.className = '';
+  div.className = className;
 
   const contents = $('.contents', div);
   contents.textContent = '';


### PR DESCRIPTION
* Remove "Mozilla Format" header and move icon to the right of the import/export buttons as mentioned in our discussion in Discord.
* Make editable help modal styles match the manage help modal style. Only the informational popups have extra padding around the content.
