### PR TITLE
Change target of CSSLint "full list of rules" link

### DIFF
--- a/edit/lint.js
+++ b/edit/lint.js
@@ -363,7 +363,7 @@ function showLintHelp() {
     : 'https://github.com/CSSLint/csslint/issues/535';
   let headerLink, template, csslintRules;
   if (linter === 'csslint') {
-    headerLink = $createLink('https://github.com/CSSLint/csslint/wiki/Rules-by-ID', 'CSSLint');
+    headerLink = $createLink('https://github.com/CSSLint/csslint/wiki/Rules', 'CSSLint');
     template = ruleID => {
       const rule = csslintRules.find(rule => rule.id === ruleID);
       return rule &&


### PR DESCRIPTION
The "See a full list of rules" link in the CSSLint settings popup currently points to https://github.com/CSSLint/csslint/wiki/Rules-by-ID which is... rather sparse.

Instead, link to https://github.com/CSSLint/csslint/wiki/Rules 

It contains all of the same rules / documentation-page links, but presents slightly more information to the user up front, without forcing them to click on each rule just to get an explanation of what it is.