### PR TITLE
Prevent button label to exceed button

### DIFF
--- a/msgbox/msgbox.css
+++ b/msgbox/msgbox.css
@@ -140,6 +140,7 @@
 
 #message-box-buttons button {
   margin: 0 .375rem;
+  width: auto;
 }
 
 /* popup */


### PR DESCRIPTION
Stylus options: shortcut popup and infoboxes:
Translations for "close" can have more characters.
Override the fixed 60px inherited from `button, input[type="number"], input[type="color"], select, .onoffswitch`.
![ss](https://user-images.githubusercontent.com/1388389/41406388-8baf220e-6fcc-11e8-811a-a85147136bb6.png)
