### PR TITLE
Fix 'browser_style' warning

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -97,6 +97,7 @@
     }
   ],
   "browser_action": {
+    "browser_style": true,
     "default_icon": {
       "16": "/images/icon/16w.png",
       "32": "/images/icon/32w.png",


### PR DESCRIPTION
Here's a simple fix for the warning below, seen in Firefox console:
`addons.webextension.{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d} WARN Please specify whether you want browser_style or not in your browser_action options.`