### PR TITLE
Add number & range Usercss variables (#492)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1051,6 +1051,15 @@
     },
     "description": "Error displayed when the value of @var color is invalid"
   },
+  "styleMetaErrorRangeOrNumber": {
+    "message": "Invalid @var $type$: value must be an array containing at least one number at index zero",
+    "description": "Error displayed when the value of @var number or @var range is invalid",
+    "placeholders": {
+      "type": {
+        "content": "$1"
+      }
+    }
+  },
   "styleMetaErrorPreprocessor": {
     "message": "Unsupported @preprocessor: $preprocessor$",
     "placeholders": {

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -226,7 +226,7 @@ var usercss = (() => {
           result.default = range[0];
           result.min = range[1];
           result.max = range[2];
-          result.step = range[3] || 1;
+          result.step = range[3] == 0 ? 1 : range[3];
         }
         break;
       }

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -198,7 +198,7 @@ var usercss = (() => {
         if (Array.isArray(state.value)) {
           result.options = state.value.map(text => {
             if (text.endsWith('*')) {
-              text = text.replace(/\*$/, '');
+              text = text.slice(0, -1);
               defaultValue = text;
             }
             return createOption(text);
@@ -206,8 +206,8 @@ var usercss = (() => {
         } else {
           result.options = Object.keys(state.value).map(k => {
             if (k.endsWith('*')) {
-              state.value[k] = state.value[k].replace(/\*$/, '');
-              k = k.replace(/\*$/, '');
+              state.value[k] = state.value[k].slice(0, -1);
+              k = k.slice(0, -1);
               defaultValue = k;
             }
             return createOption(k, state.value[k]);

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -217,6 +217,7 @@ var usercss = (() => {
         break;
       }
 
+      case 'number':
       case 'range': {
         state.errorPrefix = 'Invalid JSON: ';
         parseJSONValue(state);

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -221,10 +221,10 @@ var usercss = (() => {
         state.errorPrefix = 'Invalid JSON: ';
         parseJSONValue(state);
         state.errorPrefix = '';
-        // [ start, end, step, default ]
-        if (Array.isArray(state.value) && state.value.length === 4) {
+        // [default, start, end, step] (start, end & step are optional)
+        if (Array.isArray(state.value) && state.value.length) {
+          result.default = state.value.shift();
           result.range = state.value;
-          result.default = state.value[3];
         } else {
           // not a range, fallback to text
           result.type = 'text';

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -177,7 +177,7 @@ var usercss = (() => {
     result.label = state.value;
 
     const {re, type, text} = state;
-    let deflt;
+    let defaultValue;
 
     switch (type === 'image' && state.key === 'var' ? '@image@var' : type) {
       case 'checkbox': {
@@ -199,7 +199,7 @@ var usercss = (() => {
           result.options = state.value.map(text => {
             if (text.endsWith('*')) {
               text = text.replace(/\*$/, '');
-              deflt = text;
+              defaultValue = text;
             }
             return createOption(text);
           });
@@ -208,12 +208,12 @@ var usercss = (() => {
             if (k.endsWith('*')) {
               state.value[k] = state.value[k].replace(/\*$/, '');
               k = k.replace(/\*$/, '');
-              deflt = k;
+              defaultValue = k;
             }
             return createOption(k, state.value[k]);
           });
         }
-        result.default = typeof deflt !== 'undefined' ? deflt : (result.options[0] || {}).name || '';
+        result.default = typeof defaultValue !== 'undefined' ? defaultValue : (result.options[0] || {}).name || '';
         break;
       }
 

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -263,7 +263,7 @@ var usercss = (() => {
       }
 
       default: {
-        // text, color, number
+        // text, color
         parseStringToEnd(state);
         result.default = state.value;
       }

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -194,30 +194,18 @@ var usercss = (() => {
         state.errorPrefix = 'Invalid JSON: ';
         parseJSONValue(state);
         state.errorPrefix = '';
-        const extractDefault = text => {
-          if (text.endsWith('*')) {
-            return text.slice(0, -1);
+        const extractDefaultOption = (key, value) => {
+          if (key.endsWith('*')) {
+            const option = createOption(key.slice(0, -1), value);
+            result.default = option.name;
+            return option;
           }
-          return false;
+          return createOption(key, value);
         };
         if (Array.isArray(state.value)) {
-          result.options = state.value.map(text => {
-            const isDefault = extractDefault(text);
-            if (isDefault) {
-              result.default = isDefault;
-            }
-            return createOption(isDefault || text);
-          });
+          result.options = state.value.map(k => extractDefaultOption(k));
         } else {
-          result.options = Object.keys(state.value).map(k => {
-            const isDefault = extractDefault(k);
-            const value = state.value[k];
-            if (isDefault) {
-              k = isDefault;
-              result.default = k;
-            }
-            return createOption(k, value);
-          });
+          result.options = Object.keys(state.value).map(k => extractDefaultOption(k, state.value[k]));
         }
         if (result.default === null) {
           result.default = (result.options[0] || {}).name || '';

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -222,7 +222,7 @@ var usercss = (() => {
         if (Array.isArray(state.value) && state.value.length) {
           // label may be placed anywhere
           result.units = (state.value.find(i => typeof i === 'string') || '').replace(/[\d.+-]/g, '');
-          const range = state.value.filter(i => typeof i === 'number');
+          const range = state.value.filter(i => typeof i === 'number' || i == null);
           result.default = range[0];
           result.min = range[1];
           result.max = range[2];

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -231,10 +231,6 @@ var usercss = (() => {
           // but should not contain any numbers '4px' => 'px'
           result.units = labelIndex < 0 ? '' : state.value.splice(labelIndex, 1)[0].toString().replace(/[\d.+-]/g, '');
           result.range = state.value.filter(item => !nonDigit.test(item));
-        } else {
-          // not a range, fallback to text
-          result.type = 'text';
-          result.default = state.value;
         }
         break;
       }
@@ -617,6 +613,11 @@ var usercss = (() => {
       throw new Error(chrome.i18n.getMessage('styleMetaErrorCheckbox'));
     } else if (va.type === 'color') {
       va[value] = colorConverter.format(colorConverter.parse(va[value]), 'rgb');
+    } else if (
+      (va.type === 'number' || va.type === 'range') &&
+      !(typeof va[value] === 'number' || Array.isArray(va.range))
+    ) {
+      throw new Error(chrome.i18n.getMessage('styleMetaErrorRangeOrNumber', va.type));
     }
   }
 

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -238,7 +238,7 @@ var usercss = (() => {
           result.default = range[0];
           result.min = range[1];
           result.max = range[2];
-          result.step = range[3];
+          result.step = range[3] || 1;
         }
         break;
       }

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -29,7 +29,7 @@ var usercss = (() => {
     ['version', 0],
   ]);
   const MANDATORY_META = ['name', 'namespace', 'version'];
-  const META_VARS = ['text', 'color', 'checkbox', 'select', 'dropdown', 'image'];
+  const META_VARS = ['text', 'color', 'checkbox', 'select', 'dropdown', 'image', 'number', 'range'];
   const META_URLS = [...KNOWN_META.keys()].filter(k => k.endsWith('URL'));
 
   const BUILDER = {
@@ -203,6 +203,22 @@ var usercss = (() => {
         break;
       }
 
+      case 'range': {
+        state.errorPrefix = 'Invalid JSON: ';
+        parseJSONValue(state);
+        state.errorPrefix = '';
+        // [ start, end, step, default ]
+        if (Array.isArray(state.value) && state.value.length === 4) {
+          result.range = state.value;
+          result.default = state.value[3];
+        } else {
+          // not a range, fallback to text
+          result.type = 'text';
+          result.default = state.value;
+        }
+        break;
+      }
+
       case 'dropdown':
       case 'image': {
         if (text[re.lastIndex] !== '{') {
@@ -235,7 +251,7 @@ var usercss = (() => {
       }
 
       default: {
-        // text, color
+        // text, color, number
         parseStringToEnd(state);
         result.default = state.value;
       }

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -177,6 +177,7 @@ var usercss = (() => {
     result.label = state.value;
 
     const {re, type, text} = state;
+    let deflt;
 
     switch (type === 'image' && state.key === 'var' ? '@image@var' : type) {
       case 'checkbox': {
@@ -195,11 +196,24 @@ var usercss = (() => {
         parseJSONValue(state);
         state.errorPrefix = '';
         if (Array.isArray(state.value)) {
-          result.options = state.value.map(text => createOption(text));
+          result.options = state.value.map(text => {
+            if (text.endsWith('*')) {
+              text = text.replace(/\*$/, '');
+              deflt = text;
+            }
+            return createOption(text);
+          });
         } else {
-          result.options = Object.keys(state.value).map(k => createOption(k, state.value[k]));
+          result.options = Object.keys(state.value).map(k => {
+            if (k.endsWith('*')) {
+              state.value[k] = state.value[k].replace(/\*$/, '');
+              k = k.replace(/\*$/, '');
+              deflt = k;
+            }
+            return createOption(k, state.value[k]);
+          });
         }
-        result.default = (result.options[0] || {}).name || '';
+        result.default = typeof deflt !== 'undefined' ? deflt : (result.options[0] || {}).name || '';
         break;
       }
 

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -232,10 +232,13 @@ var usercss = (() => {
         state.errorPrefix = '';
         // [default, start, end, step, units] (start, end, step & units are optional)
         if (Array.isArray(state.value) && state.value.length) {
-          result.default = state.value.shift();
-          // label may be placed anywhere after default value
+          // label may be placed anywhere
           result.units = (state.value.find(i => typeof i === 'string') || '').replace(/[\d.+-]/g, '');
-          result.range = state.value.filter(i => typeof i === 'number');
+          const range = state.value.filter(i => typeof i === 'number');
+          result.default = range[0];
+          result.min = range[1];
+          result.max = range[2];
+          result.step = range[3];
         }
         break;
       }
@@ -618,10 +621,7 @@ var usercss = (() => {
       throw new Error(chrome.i18n.getMessage('styleMetaErrorCheckbox'));
     } else if (va.type === 'color') {
       va[value] = colorConverter.format(colorConverter.parse(va[value]), 'rgb');
-    } else if (
-      (va.type === 'number' || va.type === 'range') &&
-      (typeof va[value] !== 'number' || !Array.isArray(va.range))
-    ) {
+    } else if ((va.type === 'number' || va.type === 'range') && typeof va[value] !== 'number') {
       throw new Error(chrome.i18n.getMessage('styleMetaErrorRangeOrNumber', va.type));
     }
   }

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -222,11 +222,11 @@ var usercss = (() => {
         if (Array.isArray(state.value) && state.value.length) {
           // label may be placed anywhere
           result.units = (state.value.find(i => typeof i === 'string') || '').replace(/[\d.+-]/g, '');
-          const range = state.value.filter(i => typeof i === 'number' || i == null);
+          const range = state.value.filter(i => typeof i === 'number' || i === null);
           result.default = range[0];
           result.min = range[1];
           result.max = range[2];
-          result.step = range[3] == 0 ? 1 : range[3];
+          result.step = range[3] === 0 ? 1 : range[3];
         }
         break;
       }

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -224,7 +224,7 @@ var usercss = (() => {
         state.errorPrefix = '';
         // [default, start, end, step, units] (start, end, step & units are optional)
         if (Array.isArray(state.value) && state.value.length) {
-          result.default = state.value.shift();
+          result.default = parseFloat(state.value.shift());
           const nonDigit = /[^\d.+-]/;
           // label may be placed anywhere after default value
           const labelIndex = state.value.findIndex(item => nonDigit.test(item));

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -222,10 +222,15 @@ var usercss = (() => {
         state.errorPrefix = 'Invalid JSON: ';
         parseJSONValue(state);
         state.errorPrefix = '';
-        // [default, start, end, step] (start, end & step are optional)
+        // [default, start, end, step, units] (start, end, step & units are optional)
         if (Array.isArray(state.value) && state.value.length) {
           result.default = state.value.shift();
-          result.range = state.value;
+          const nonDigit = /[^\d.+-]/;
+          // label may be placed anywhere after default value
+          const labelIndex = state.value.findIndex(item => nonDigit.test(item));
+          // but should not contain any numbers '4px' => 'px'
+          result.units = labelIndex < 0 ? '' : state.value.splice(labelIndex, 1)[0].toString().replace(/[\d.+-]/g, '');
+          result.range = state.value.filter(item => !nonDigit.test(item));
         } else {
           // not a range, fallback to text
           result.type = 'text';
@@ -571,6 +576,9 @@ var usercss = (() => {
     if (va.type === 'select' || va.type === 'dropdown' || va.type === 'image') {
       // TODO: handle customized image
       return va.options.find(o => o.name === va[prop]).value;
+    }
+    if ((va.type === 'number' || va.type === 'range') && va.units) {
+      return va[prop] + va.units;
     }
     return va[prop];
   }

--- a/manage/config-dialog.css
+++ b/manage/config-dialog.css
@@ -104,7 +104,7 @@
   margin-right: 4px;
 }
 
-.config-range span {
+.config-number span, .config-range span {
   line-height: 22px;
 }
 

--- a/manage/config-dialog.css
+++ b/manage/config-dialog.css
@@ -107,16 +107,6 @@
   line-height: 22px;
 }
 
-.current-range:before {
-  content: attr(data-min);
-  padding-right: .25em;
-}
-
-.current-range:after {
-  content: attr(data-max);
-  padding-left: .25em;
-}
-
 .config-body label:not(.nondefault) .config-reset-icon {
   visibility: hidden;
 }

--- a/manage/config-dialog.css
+++ b/manage/config-dialog.css
@@ -94,7 +94,8 @@
   flex-shrink: 0;
 }
 
-.config-value:not(.onoffswitch):not(.select-resizer) > :not(:last-child) {
+.config-value:not(.onoffswitch):not(.select-resizer) > :not(:last-child),
+.current-value {
   margin-right: 4px;
 }
 

--- a/manage/config-dialog.css
+++ b/manage/config-dialog.css
@@ -94,9 +94,28 @@
   flex-shrink: 0;
 }
 
-.config-value:not(.onoffswitch):not(.select-resizer) > :not(:last-child),
-.current-value {
+.config-value:not(.onoffswitch):not(.select-resizer) > :not(:last-child) {
   margin-right: 4px;
+}
+
+.current-value {
+  outline: 1px solid rgba(128, 128, 128, 0.5);
+  padding: 2px 4px;
+  margin-right: 4px;
+}
+
+.config-range span {
+  line-height: 22px;
+}
+
+.current-range:before {
+  content: attr(data-min);
+  padding-right: .25em;
+}
+
+.current-range:after {
+  content: attr(data-max);
+  padding-left: .25em;
 }
 
 .config-body label:not(.nondefault) .config-reset-icon {

--- a/manage/config-dialog.css
+++ b/manage/config-dialog.css
@@ -99,10 +99,9 @@
 }
 
 .current-value {
-  outline: 1px solid rgba(128, 128, 128, 0.5);
   padding: 2px 4px;
   margin-right: 4px;
-}
+ }
 
 .config-number span, .config-range span {
   line-height: 22px;

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -328,12 +328,11 @@ function configDialog(style) {
 
   // Clamp input[type=number] to a valid range
   function clampValue(value, va, break = false) {
-    const max = isNumber(va.max) ? va.max : 100;
     if (isNumber(va.min) && value < va.min) {
-      return min;
+      return va.min;
     }
-    if (value > max) {
-      return max;
+    if (isNumber(va.max) && value > va.max) {
+      return va.max;
     }
     // Don't restrict to integer values if step is undefined.
     if (!isNumber(va.step) || break) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -213,7 +213,7 @@ function configDialog(style) {
         ])
       ]);
     for (const va of vars) {
-      let children, options;
+      let children;
       switch (va.type) {
         case 'color':
           children = [
@@ -258,8 +258,8 @@ function configDialog(style) {
           ];
           break;
 
-        default:
-          options = {
+        default: {
+          const options = {
             va,
             type: va.type,
             onchange: updateVarOnChange,
@@ -280,8 +280,8 @@ function configDialog(style) {
               va.input = $create('input.config-value', options),
             ];
           }
+        }
 
-          break;
       }
 
       resetter = resetter.cloneNode(true);

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -327,7 +327,7 @@ function configDialog(style) {
   }
 
   // Clamp input[type=number] to a valid range
-  function clampValue(value, va) {
+  function clampValue(value, va, break = false) {
     const max = isNumber(va.max) ? va.max : 100;
     if (isNumber(va.min) && value < va.min) {
       return min;
@@ -336,14 +336,14 @@ function configDialog(style) {
       return max;
     }
     // Don't restrict to integer values if step is undefined.
-    if (!isNumber(va.step)) {
+    if (!isNumber(va.step) || break) {
       return value;
     }
     const step = va.step || 1;
-    const precision = (step.toString().split('.')[1] || 0).length + 1;
-    const inv = 1 / step;
-    // ECMA-262 only requires a precision of up to 21 significant digits
-    return Number((Math.floor(inv * value) / inv).toPrecision(precision > 21 ? 21 : precision));
+    const scale = 10 ** (step.toString().split('.')[1] || '').length;
+    value = Math.round((value * scale) / (step * scale)) * (step * scale) / scale;
+    // clamp modified value; skip step check
+    return clampValue(value, va, true);
   }
 
   function updateVarOnInput(event, debounced = false) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -328,14 +328,15 @@ function configDialog(style) {
         }
       } else if (va.type === 'checkbox') {
         va.input.checked = Number(value);
-      }
-      if (va.type === 'range') {
+      } else if (va.type === 'range') {
         const span = $('.current-value', va.input.parentNode);
+        va.input.value = value;
         if (span) {
           span.textContent = value;
         }
+      } else {
+        va.input.value = value;
       }
-      va.input.value = value;
       if (!prefs.get('config.autosave')) {
         renderValueState(va);
       }

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -314,7 +314,7 @@ function configDialog(style) {
   function updateVarOnChange() {
     if (this.type === 'range') {
       this.va.value = Number(this.value);
-      $('.current-value', this.closest('.config-range')).textContent = this.va.value + (this.va.units || '');
+      updateRangeCurrentValue(va, this.va.value);
     } else if (this.type === 'number') {
       const value = Number(this.value);
       if (clampValue(value, this.va) === value) {
@@ -342,6 +342,13 @@ function configDialog(style) {
     return value;
   }
 
+  function updateRangeCurrentValue(va, value) {
+    const span = $('.current-value', va.input.closest('.config-range'));
+    if (span) {
+      span.textContent = value + (va.units || '');
+    }
+  }
+
   function updateVarOnInput(event, debounced = false) {
     if (debounced) {
       event.target.dispatchEvent(new Event('change', {bubbles: true}));
@@ -365,11 +372,8 @@ function configDialog(style) {
       } else if (va.type === 'checkbox') {
         va.input.checked = Number(value);
       } else if (va.type === 'range') {
-        const span = $('.current-value', va.input.closest('.config-range'));
         va.input.value = value;
-        if (span) {
-          span.textContent = value + (va.units || '');
-        }
+        updateRangeCurrentValue(va, va.input.value);
       } else {
         va.input.value = value;
       }

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -328,9 +328,8 @@ function configDialog(style) {
 
   // Clamp input[type=number] to a valid range
   function clampValue(value, va) {
-    const min = typeof va.min === 'undefined' ? 0 : va.min;
-    const max = typeof va.max === 'undefined' ? 100 : va.max;
-    if (value < min) {
+    const max = isNumber(va.max) ? va.max : 100;
+    if (isNumber(va.min) && value < va.min) {
       return min;
     }
     if (value > max) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -198,7 +198,7 @@ function configDialog(style) {
   }
 
   function isNumber(value) {
-    return value !== '' && !isNaN(Number(value));
+    return value !== null && value !== '' && !isNaN(Number(value));
   }
 
   function isDefault(va) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -314,12 +314,13 @@ function configDialog(style) {
   }
 
   function updateVarOnChange() {
-    this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     if (this.type === 'number') {
       this.value = this.va.value = clampValue(this.value, this.va.range);
-    }
-    if (this.type === 'range') {
+    } else if (this.type === 'range') {
       $('.current-value', this.closest('.config-range')).textContent = this.va.value + (this.va.units || '');
+      this.va.value = parseFloat(this.value);
+    } else {
+      this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     }
   }
 

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -316,6 +316,9 @@ function configDialog(style) {
     if (this.type === 'range') {
       this.va.value = Number(this.value);
       $('.current-value', this.closest('.config-range')).textContent = this.va.value + (this.va.units || '');
+    } else if (this.type === 'number') {
+      // clamp stored value
+      this.va.value = clampValue(this.value, this.va);
     } else {
       this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     }
@@ -323,6 +326,7 @@ function configDialog(style) {
 
   // Applied to input[type=number]
   function updateVarOnBlur() {
+    // clamp value visible to user
     this.value = this.va.value = clampValue(this.value, this.va);
   }
 

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -201,20 +201,6 @@ function configDialog(style) {
     return va.value === null || va.value === undefined || va.value === va.default;
   }
 
-  function rangeToProps(range = []) {
-    const dataset = {};
-    if (range.length > 0) {
-      dataset.min = range[0];
-    }
-    if (range.length > 1) {
-      dataset.max = range[1];
-    }
-    if (range[2]) {
-      dataset.step = range[2];
-    }
-    return dataset;
-  }
-
   function buildConfigForm() {
     let resetter =
       $create('a.config-reset-icon', {href: '#'}, [
@@ -280,7 +266,9 @@ function configDialog(style) {
               va,
               type: va.type,
               value: va.default,
-              ...rangeToProps(va.range),
+              min: va.min,
+              max: va.max,
+              step: va.step,
               onchange: updateVarOnChange
             })
           ];
@@ -318,7 +306,7 @@ function configDialog(style) {
 
   function updateVarOnChange() {
     if (this.type === 'number') {
-      this.value = this.va.value = clampValue(this.value, this.va.range);
+      this.value = this.va.value = clampValue(this.value, this.va);
     } else if (this.type === 'range') {
       this.va.value = parseFloat(this.value);
       $('.current-value', this.closest('.config-range')).textContent = this.va.value + (this.va.units || '');
@@ -328,16 +316,16 @@ function configDialog(style) {
   }
 
   // Clamp input[type=number] to a valid range
-  function clampValue(value, [min = 0, max = 100, step]) {
-    if (value < min) {
-      return min;
+  function clampValue(value, va) {
+    if (value < (va.min || 0)) {
+      return va.min;
     }
-    if (value > max) {
-      return max;
+    if (value > (va.max || 100)) {
+      return va.max;
     }
-    const inv = 1 / (step || 1);
+    const inv = 1 / (va.step || 1);
     // Don't restrict to integer values if step is undefined.
-    return typeof step !== 'undefined' ? Math.floor(inv * value) / inv : value;
+    return typeof va.step !== 'undefined' ? Math.floor(inv * value) / inv : value;
   }
 
   function updateVarOnInput(event, debounced = false) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -264,6 +264,7 @@ function configDialog(style) {
             va,
             type: va.type,
             onfocus: va.type === 'number' ? selectAllOnFocus : null,
+            onblur: va.type === 'number' ? updateVarOnBlur : null,
             onchange: updateVarOnChange,
             oninput: updateVarOnInput
           };
@@ -311,15 +312,23 @@ function configDialog(style) {
     }
   }
 
+  function updateVarOnBlur(e = {}) {
+    const value = Number(this.value);
+    const clamped = clampValue(value, this.va);
+    if (clamped === value) {
+      this.va.value = value;
+    }
+    if (e.type === 'blur') {
+      this.value = clamped;
+    }
+  }
+
   function updateVarOnChange() {
     if (this.type === 'range') {
       this.va.value = Number(this.value);
       updateRangeCurrentValue(this.va, this.va.value);
     } else if (this.type === 'number') {
-      const value = Number(this.value);
-      if (clampValue(value, this.va) === value) {
-        this.va.value = value;
-      }
+      updateVarOnBlur.call(this);
     } else {
       this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     }

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -264,7 +264,6 @@ function configDialog(style) {
             va,
             type: va.type,
             onfocus: va.type === 'number' ? selectAllOnFocus : null,
-            onblur: va.type === 'number' ? updateVarOnBlur : null,
             onchange: updateVarOnChange,
             oninput: updateVarOnInput
           };
@@ -317,17 +316,13 @@ function configDialog(style) {
       this.va.value = Number(this.value);
       $('.current-value', this.closest('.config-range')).textContent = this.va.value + (this.va.units || '');
     } else if (this.type === 'number') {
-      // clamp stored value
-      this.va.value = clampValue(this.value, this.va);
+      const value = Number(this.value);
+      if (clampValue(value, this.va) === value) {
+        this.va.value = value;
+      }
     } else {
       this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     }
-  }
-
-  // Applied to input[type=number]
-  function updateVarOnBlur() {
-    // clamp value visible to user
-    this.value = this.va.value = clampValue(this.value, this.va);
   }
 
   // Clamp input[type=number] to a valid range

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -314,7 +314,7 @@ function configDialog(style) {
   function updateVarOnChange() {
     if (this.type === 'range') {
       this.va.value = Number(this.value);
-      updateRangeCurrentValue(va, this.va.value);
+      updateRangeCurrentValue(this.va, this.va.value);
     } else if (this.type === 'number') {
       const value = Number(this.value);
       if (clampValue(value, this.va) === value) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -197,8 +197,12 @@ function configDialog(style) {
     renderValues();
   }
 
+  function isNullOrUndefined(value) {
+    return value === null || value === undefined;
+  }
+
   function isDefault(va) {
-    return va.value === null || va.value === undefined || va.value === va.default;
+    return isNullOrUndefined(va.value) || va.value === va.default;
   }
 
   function buildConfigForm() {
@@ -259,33 +263,40 @@ function configDialog(style) {
           break;
 
         case 'range':
-        case 'number':
-          children = [
-            va.type === 'range' && $create('span.current-value', {textContent: va.value + va.units}),
-            va.input = $create('input.config-value', {
-              va,
-              type: va.type,
-              value: va.default,
-              min: va.min,
-              max: va.max,
-              step: va.step,
-              onchange: updateVarOnChange
-            })
-          ];
-          break;
-
-        default: {
+        case 'number': {
           const options = {
             va,
             type: va.type,
+            onfocus: va.type === 'number' ? selectAllOnFocus : null,
             onchange: updateVarOnChange,
-            oninput: updateVarOnInput,
-            onfocus: selectAllOnFocus,
+            oninput: updateVarOnInput
           };
+          if (!isNullOrUndefined(va.min)) {
+            options.min = va.min;
+          }
+          if (!isNullOrUndefined(va.max)) {
+            options.max = va.max;
+          }
+          if (!isNullOrUndefined(va.step)) {
+            options.step = va.step;
+          }
           children = [
-            va.input = $create('input.config-value', options),
+            va.type === 'range' && $create('span.current-value'),
+            va.input = $create('input.config-value', options)
           ];
+          break;
         }
+
+        default:
+          children = [
+            va.input = $create('input.config-value', {
+              va,
+              type: va.type,
+              onchange: updateVarOnChange,
+              oninput: updateVarOnInput,
+              onfocus: selectAllOnFocus,
+            }),
+          ];
 
       }
 
@@ -308,7 +319,7 @@ function configDialog(style) {
     if (this.type === 'number') {
       this.value = this.va.value = clampValue(this.value, this.va);
     } else if (this.type === 'range') {
-      this.va.value = parseFloat(this.value);
+      this.va.value = Number(this.value);
       $('.current-value', this.closest('.config-range')).textContent = this.va.value + (this.va.units || '');
     } else {
       this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -310,9 +310,24 @@ function configDialog(style) {
 
   function updateVarOnChange() {
     this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
+    if (this.type === 'number') {
+      this.value = this.va.value = clampValue(this.value, this.va.range);
+    }
     if (this.type === 'range') {
       $('.current-value', this.closest('.config-range')).textContent = this.va.value;
     }
+  }
+
+  // Clamp input[type=number] to a valid range
+  function clampValue(value, [min = 0, max = 100, step]) {
+    if (value < min) {
+      return min;
+    } else if (value > max) {
+      return max;
+    }
+    const remainder = value % (step || 1);
+    // Don't restrict to integer values if step is undefined.
+    return typeof step !== 'undefined' && remainder !== 0 ? value - remainder : value;
   }
 
   function updateVarOnInput(event, debounced = false) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -317,8 +317,8 @@ function configDialog(style) {
 
   // Clamp input[type=number] to a valid range
   function clampValue(value, va) {
-    const min = va.min || 0;
-    const max = va.max || 100;
+    const min = typeof va.min === 'undefined' ? 0 : va.min;
+    const max = typeof va.max === 'undefined' ? 100 : va.max;
     if (value < min) {
       return min;
     }

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -198,7 +198,7 @@ function configDialog(style) {
   }
 
   function isNumber(value) {
-    return value !== null && value !== '' && !isNaN(Number(value));
+    return typeof value === 'number';
   }
 
   function isDefault(va) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -363,6 +363,9 @@ function configDialog(style) {
 
   function renderValues(varsToRender = vars) {
     for (const va of varsToRender) {
+      if (va.input === document.activeElement) {
+        continue;
+      }
       const value = isDefault(va) ? va.default : va.value;
       if (va.type === 'color') {
         va.input.style.backgroundColor = value;

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -197,10 +197,6 @@ function configDialog(style) {
     renderValues();
   }
 
-  function isNumber(value) {
-    return typeof value === 'number';
-  }
-
   function isDefault(va) {
     return va.value === null || va.value === undefined || va.value === va.default;
   }
@@ -272,13 +268,13 @@ function configDialog(style) {
             onchange: updateVarOnChange,
             oninput: updateVarOnInput
           };
-          if (isNumber(va.min)) {
+          if (typeof va.min === 'number') {
             options.min = va.min;
           }
-          if (isNumber(va.max)) {
+          if (typeof va.max === 'number') {
             options.max = va.max;
           }
-          if (isNumber(va.step) && isFinite(Number(va.step))) {
+          if (typeof va.step === 'number' && isFinite(va.step)) {
             options.step = va.step;
           }
           children = [
@@ -333,15 +329,15 @@ function configDialog(style) {
   // Clamp input[type=number] to a valid range
   function clampValue(value, va) {
     // Don't restrict to integer values if step is undefined.
-    if (isNumber(va.step)) {
+    if (typeof va.step === 'number') {
       const step = va.step || 1;
       const scale = 10 ** (step.toString().split('.')[1] || '').length;
       value = Math.round((value * scale) / (step * scale)) * (step * scale) / scale;
     }
-    if (isNumber(va.min) && value < va.min) {
+    if (typeof va.min === 'number' && value < va.min) {
       return va.min;
     }
-    if (isNumber(va.max) && value > va.max) {
+    if (typeof va.max === 'number' && value > va.max) {
       return va.max;
     }
     return value;

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -264,7 +264,7 @@ function configDialog(style) {
             type: va.type,
             onchange: updateVarOnChange,
             oninput: updateVarOnInput,
-            onfocus: focusInput,
+            onfocus: selectAllOnFocus,
           };
           if (va.type === 'range') {
             options.min = va.range[0];
@@ -314,7 +314,7 @@ function configDialog(style) {
     }
   }
 
-  function focusInput(event) {
+  function selectAllOnFocus(event) {
     event.target.select();
   }
 

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -197,12 +197,12 @@ function configDialog(style) {
     renderValues();
   }
 
-  function isNullOrUndefined(value) {
-    return value === null || value === undefined;
+  function isNumber(value) {
+    return value !== '' && !isNaN(Number(value));
   }
 
   function isDefault(va) {
-    return isNullOrUndefined(va.value) || va.value === va.default;
+    return va.value === null || va.value === undefined || va.value === va.default;
   }
 
   function buildConfigForm() {
@@ -271,13 +271,13 @@ function configDialog(style) {
             onchange: updateVarOnChange,
             oninput: updateVarOnInput
           };
-          if (!isNullOrUndefined(va.min)) {
+          if (isNumber(va.min)) {
             options.min = va.min;
           }
-          if (!isNullOrUndefined(va.max)) {
+          if (isNumber(va.max)) {
             options.max = va.max;
           }
-          if (!isNullOrUndefined(va.step)) {
+          if (isNumber(va.step) && isFinite(Number(va.step))) {
             options.step = va.step;
           }
           children = [

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -273,7 +273,7 @@ function configDialog(style) {
           break;
 
         case 'range':
-        case 'number': {
+        case 'number':
           children = [
             va.type === 'range' && $create('span.current-value', {textContent: va.value + va.units}),
             va.input = $create('input.config-value', {
@@ -285,7 +285,6 @@ function configDialog(style) {
             })
           ];
           break;
-        }
 
         default: {
           const options = {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -264,6 +264,7 @@ function configDialog(style) {
             type: va.type,
             onchange: updateVarOnChange,
             oninput: updateVarOnInput,
+            onfocus: focusInput,
           };
           if (va.type === 'range') {
             options.min = va.range[0];
@@ -311,6 +312,10 @@ function configDialog(style) {
     } else {
       debounce(updateVarOnInput, AUTOSAVE_DELAY, event, true);
     }
+  }
+
+  function focusInput(event) {
+    event.target.select();
   }
 
   function renderValues(varsToRender = vars) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -336,7 +336,7 @@ function configDialog(style) {
       return max;
     }
     // Don't restrict to integer values if step is undefined.
-    if (typeof va.step === 'undefined') {
+    if (!isNumber(va.step)) {
       return value;
     }
     const step = va.step || 1;

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -266,14 +266,23 @@ function configDialog(style) {
             oninput: updateVarOnInput,
             onfocus: selectAllOnFocus,
           };
+          const dataset = {};
           if (va.type === 'range') {
-            options.min = va.range[0];
-            options.max = va.range[1];
-            options.step = va.range[2];
             options.value = va.default;
+            if (typeof va.range[0] !== 'undefined') {
+              options.min = dataset.min = va.range[0];
+            }
+            if (typeof va.range[1] !== 'undefined') {
+              options.max = dataset.max = va.range[1];
+            }
+            if (va.range[2]) {
+              options.step = va.range[2];
+            }
             children = [
               $create('span.current-value', {textContent: va.value}),
-              va.input = $create('input.config-value', options),
+              $create('span.current-range', {dataset}, [
+                va.input = $create('input.config-value', options),
+              ])
             ];
           } else {
             children = [
@@ -302,7 +311,7 @@ function configDialog(style) {
   function updateVarOnChange() {
     this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     if (this.type === 'range') {
-      $('.current-value', this.parentNode).textContent = this.va.value;
+      $('.current-value', this.closest('.config-range')).textContent = this.va.value;
     }
   }
 
@@ -329,7 +338,7 @@ function configDialog(style) {
       } else if (va.type === 'checkbox') {
         va.input.checked = Number(value);
       } else if (va.type === 'range') {
-        const span = $('.current-value', va.input.parentNode);
+        const span = $('.current-value', va.input.closest('.config-range'));
         va.input.value = value;
         if (span) {
           span.textContent = value;

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -317,7 +317,6 @@ function configDialog(style) {
   }
 
   function updateVarOnChange() {
-    console.log('updateVar', this.type)
     if (this.type === 'number') {
       this.value = this.va.value = clampValue(this.value, this.va.range);
     } else if (this.type === 'range') {
@@ -326,7 +325,6 @@ function configDialog(style) {
     } else {
       this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     }
-    console.log(this.va.value);
   }
 
   // Clamp input[type=number] to a valid range

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -317,11 +317,13 @@ function configDialog(style) {
 
   // Clamp input[type=number] to a valid range
   function clampValue(value, va) {
-    if (value < (va.min || 0)) {
-      return va.min;
+    const min = va.min || 0;
+    const max = va.max || 100;
+    if (value < min) {
+      return min;
     }
-    if (value > (va.max || 100)) {
-      return va.max;
+    if (value > max) {
+      return max;
     }
     const inv = 1 / (va.step || 1);
     // Don't restrict to integer values if step is undefined.

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -266,7 +266,8 @@ function configDialog(style) {
             onfocus: va.type === 'number' ? selectAllOnFocus : null,
             onblur: va.type === 'number' ? updateVarOnBlur : null,
             onchange: updateVarOnChange,
-            oninput: updateVarOnInput
+            oninput: updateVarOnInput,
+            required: true
           };
           if (typeof va.min === 'number') {
             options.min = va.min;
@@ -312,15 +313,8 @@ function configDialog(style) {
     }
   }
 
-  function updateVarOnBlur(e = {}) {
-    const value = Number(this.value);
-    const clamped = clampValue(value, this.va);
-    if (clamped === value) {
-      this.va.value = value;
-    }
-    if (e.type === 'blur') {
-      this.value = clamped;
-    }
+  function updateVarOnBlur() {
+    this.value = isDefault(this.va) ? this.va.default : this.va.value;
   }
 
   function updateVarOnChange() {
@@ -328,27 +322,12 @@ function configDialog(style) {
       this.va.value = Number(this.value);
       updateRangeCurrentValue(this.va, this.va.value);
     } else if (this.type === 'number') {
-      updateVarOnBlur.call(this);
+      if (this.reportValidity()) {
+        this.va.value = Number(this.value);
+      }
     } else {
       this.va.value = this.type !== 'checkbox' ? this.value : this.checked ? '1' : '0';
     }
-  }
-
-  // Clamp input[type=number] to a valid range
-  function clampValue(value, va) {
-    // Don't restrict to integer values if step is undefined.
-    if (typeof va.step === 'number') {
-      const step = va.step || 1;
-      const scale = 10 ** (step.toString().split('.')[1] || '').length;
-      value = Math.round((value * scale) / (step * scale)) * (step * scale) / scale;
-    }
-    if (typeof va.min === 'number' && value < va.min) {
-      return va.min;
-    }
-    if (typeof va.max === 'number' && value > va.max) {
-      return va.max;
-    }
-    return value;
   }
 
   function updateRangeCurrentValue(va, value) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -325,9 +325,15 @@ function configDialog(style) {
     if (value > max) {
       return max;
     }
-    const inv = 1 / (va.step || 1);
     // Don't restrict to integer values if step is undefined.
-    return typeof va.step !== 'undefined' ? Math.floor(inv * value) / inv : value;
+    if (typeof va.step === 'undefined') {
+      return value;
+    }
+    const step = va.step || 1;
+    const precision = (step.toString().split('.')[1] || 0).length + 1;
+    const inv = 1 / step;
+    // ECMA-262 only requires a precision of up to 21 significant digits
+    return Number((Math.floor(inv * value) / inv).toPrecision(precision > 21 ? 21 : precision));
   }
 
   function updateVarOnInput(event, debounced = false) {

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -201,6 +201,27 @@ function configDialog(style) {
     return va.value === null || va.value === undefined || va.value === va.default;
   }
 
+  function handleRangeAndNumberInputs(va, options) {
+    const dataset = {};
+    options.value = va.default;
+    if (typeof va.range[0] !== 'undefined') {
+      options.min = dataset.min = va.range[0];
+    }
+    if (typeof va.range[1] !== 'undefined') {
+      options.max = dataset.max = va.range[1];
+    }
+    if (va.range[2]) {
+      options.step = va.range[2];
+    }
+    const children = va.type === 'range' ? [$create('span.current-value', {textContent: va.value + va.units})] : [];
+    children.push(
+      $create(`span.current-${va.type}`, {dataset}, [
+        va.input = $create('input.config-value', options),
+      ])
+    );
+    return children;
+  }
+
   function buildConfigForm() {
     let resetter =
       $create('a.config-reset-icon', {href: '#'}, [
@@ -266,24 +287,8 @@ function configDialog(style) {
             oninput: updateVarOnInput,
             onfocus: selectAllOnFocus,
           };
-          const dataset = {};
           if (va.type === 'range' || va.type === 'number') {
-            children = va.type === 'range' ? [$create('span.current-value', {textContent: va.value})] : [];
-            options.value = va.default;
-            if (typeof va.range[0] !== 'undefined') {
-              options.min = dataset.min = va.range[0];
-            }
-            if (typeof va.range[1] !== 'undefined') {
-              options.max = dataset.max = va.range[1];
-            }
-            if (va.range[2]) {
-              options.step = va.range[2];
-            }
-            children.push(
-              $create('span.current-range', {dataset}, [
-                va.input = $create('input.config-value', options),
-              ])
-            );
+            children = handleRangeAndNumberInputs(va, options);
           } else {
             children = [
               va.input = $create('input.config-value', options),
@@ -314,7 +319,7 @@ function configDialog(style) {
       this.value = this.va.value = clampValue(this.value, this.va.range);
     }
     if (this.type === 'range') {
-      $('.current-value', this.closest('.config-range')).textContent = this.va.value;
+      $('.current-value', this.closest('.config-range')).textContent = this.va.value + (this.va.units || '');
     }
   }
 
@@ -356,7 +361,7 @@ function configDialog(style) {
         const span = $('.current-value', va.input.closest('.config-range'));
         va.input.value = value;
         if (span) {
-          span.textContent = value;
+          span.textContent = value + (va.units || '');
         }
       } else {
         va.input.value = value;

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -267,7 +267,8 @@ function configDialog(style) {
             onfocus: selectAllOnFocus,
           };
           const dataset = {};
-          if (va.type === 'range') {
+          if (va.type === 'range' || va.type === 'number') {
+            children = va.type === 'range' ? [$create('span.current-value', {textContent: va.value})] : [];
             options.value = va.default;
             if (typeof va.range[0] !== 'undefined') {
               options.min = dataset.min = va.range[0];
@@ -278,12 +279,11 @@ function configDialog(style) {
             if (va.range[2]) {
               options.step = va.range[2];
             }
-            children = [
-              $create('span.current-value', {textContent: va.value}),
+            children.push(
               $create('span.current-range', {dataset}, [
                 va.input = $create('input.config-value', options),
               ])
-            ];
+            );
           } else {
             children = [
               va.input = $create('input.config-value', options),


### PR DESCRIPTION
Adds new usercss variables & behavior:

* Add number & range variables:
  * `@var number some-number "Number" [10, 0, 20, 1, "px"]` (`[default, min, max, step, units]`).
  * `@var range  some-range  "Range (0-10)"  [5, 0, 10, 1, "em"]` (`[default, min, max, step, units]`)
  * The `min`, `max`, `step` and `units` are optional; but added sequentially.
* Focusing on a text input will select all content.
* Default select option is set by including a `*` at the end of the key, e.g.
  * `@var select aSelect "Font"   ["Arial", "Consolas*", "Times New Roman"]`
  * ```
    @var select aSelect "Font" {
      "Arial": "arial",
      "Consolas*": "consolas",
      "Times": "Times New Roman"
    }
    ```

------

Example UserCSS:

```css
/* ==UserStyle==
@namespace      stylus#492
@name           new variables
@version        1.0.0
@description    Testing new variables
@author         Me
@var text   aTxt    "Text"    "Blah"
@var number aNum    "Margin"  [1, 0, 10, 0.5, "em"]
@var select aSelect "Font"    ["Arial", "Consolas*", "Times New Roman"]
@var range  aRange0 "Opacity" [1, 0, 1, 0.1]
@var range  aRange1 "Width"   [5, 1, 10, 1, "px"]
@var range  aRange2 "Height"  [11, 10, "vh"]
@preprocessor uso
==/UserStyle== */
@-moz-document domain("google.com") {
  body > div:last-child {
    content: '/*[[aTxt]]*/';
    margin: /*[[aNum]]*/;
    font-family: '/*[[aSelect]]*/';
    opacity: /*[[aRange0]]*/;
    width: /*[[aRange1]]*/;
    height: /*[[aRange2]]*/;
  }
}
```

![](https://user-images.githubusercontent.com/136959/45601540-35b41600-b9d4-11e8-8229-939460c3b5e7.png)

