### PR TITLE
Fix: prefs doesn't work in FF's private windows

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -312,6 +312,21 @@ window.addEventListener('storageReady', function _() {
   updateAPI(null, prefs.get('exposeIframes'));
 }
 
+// register hotkeys
+if (FIREFOX && browser.commands && browser.commands.update) {
+  const hotkeyPrefs = Object.keys(prefs.defaults).filter(k => k.startsWith('hotkey.'));
+  this.subscribe(hotkeyPrefs, (name, value) => {
+    try {
+      name = name.split('.')[1];
+      if (value.trim()) {
+        browser.commands.update({name, shortcut: value}).catch(ignoreChromeError);
+      } else {
+        browser.commands.reset(name).catch(ignoreChromeError);
+      }
+    } catch (e) {}
+  });
+}
+
 // *************************************************************************
 
 function webNavigationListener(method, {url, tabId, frameId}) {

--- a/background/background.js
+++ b/background/background.js
@@ -144,6 +144,18 @@ prefs.subscribe(['iconset'], () =>
     styles: {},
   }));
 
+prefs.subscribe([
+  'show-badge',
+  'disableAll',
+  'badgeDisabled',
+  'badgeNormal',
+  'iconset',
+], () =>
+  queryTabs().then(tabs =>
+    tabs.map(t => updateIcon({tab: t}))
+  )
+)
+
 // *************************************************************************
 chrome.runtime.onInstalled.addListener(({reason}) => {
   if (reason !== 'update') return;

--- a/background/background.js
+++ b/background/background.js
@@ -202,11 +202,10 @@ if (chrome.contextMenus) {
       }
       item = Object.assign({id}, item);
       delete item.presentIf;
-      const prefValue = prefs.get(id);
       item.title = chrome.i18n.getMessage(item.title);
-      if (!item.type && typeof prefValue === 'boolean') {
+      if (!item.type && typeof prefs.defaults[id] === 'boolean') {
         item.type = 'checkbox';
-        item.checked = prefValue;
+        item.checked = prefs.get(id);
       }
       if (!item.contexts) {
         item.contexts = ['browser_action'];
@@ -230,7 +229,7 @@ if (chrome.contextMenus) {
   };
 
   const keys = Object.keys(contextMenus);
-  prefs.subscribe(keys.filter(id => typeof prefs.get(id) === 'boolean'), toggleCheckmark);
+  prefs.subscribe(keys.filter(id => typeof prefs.defaults[id] === 'boolean'), toggleCheckmark);
   prefs.subscribe(keys.filter(id => contextMenus[id].presentIf), togglePresence);
   createContextMenus(keys);
 }

--- a/background/background.js
+++ b/background/background.js
@@ -150,11 +150,7 @@ prefs.subscribe([
   'badgeDisabled',
   'badgeNormal',
   'iconset',
-], () =>
-  queryTabs().then(tabs =>
-    tabs.map(t => updateIcon({tab: t}))
-  )
-);
+], () => debounce(updateAllTabsIcon));
 
 // *************************************************************************
 chrome.runtime.onInstalled.addListener(({reason}) => {
@@ -533,4 +529,10 @@ function onRuntimeMessage(msg, sender, sendResponse) {
   } else if (result !== undefined) {
     respond(result);
   }
+}
+
+function updateAllTabsIcon() {
+  return queryTabs().then(tabs =>
+    tabs.map(t => updateIcon({tab: t}))
+  );
 }

--- a/background/background.js
+++ b/background/background.js
@@ -314,7 +314,7 @@ window.addEventListener('storageReady', function _() {
 // register hotkeys
 if (FIREFOX && browser.commands && browser.commands.update) {
   const hotkeyPrefs = Object.keys(prefs.defaults).filter(k => k.startsWith('hotkey.'));
-  this.subscribe(hotkeyPrefs, (name, value) => {
+  prefs.subscribe(hotkeyPrefs, (name, value) => {
     try {
       name = name.split('.')[1];
       if (value.trim()) {

--- a/background/background.js
+++ b/background/background.js
@@ -202,7 +202,7 @@ if (chrome.contextMenus) {
       }
       item = Object.assign({id}, item);
       delete item.presentIf;
-      const prefValue = prefs.readOnlyValues[id];
+      const prefValue = prefs.get(id);
       item.title = chrome.i18n.getMessage(item.title);
       if (!item.type && typeof prefValue === 'boolean') {
         item.type = 'checkbox';
@@ -230,7 +230,7 @@ if (chrome.contextMenus) {
   };
 
   const keys = Object.keys(contextMenus);
-  prefs.subscribe(keys.filter(id => typeof prefs.readOnlyValues[id] === 'boolean'), toggleCheckmark);
+  prefs.subscribe(keys.filter(id => typeof prefs.get(id) === 'boolean'), toggleCheckmark);
   prefs.subscribe(keys.filter(id => contextMenus[id].presentIf), togglePresence);
   createContextMenus(keys);
 }
@@ -309,7 +309,7 @@ window.addEventListener('storageReady', function _() {
     window.API_METHODS.getStylesForFrame = enabled ? getStylesForFrame : getStyles;
   };
   prefs.subscribe(['exposeIframes'], updateAPI);
-  updateAPI(null, prefs.readOnlyValues.exposeIframes);
+  updateAPI(null, prefs.get('exposeIframes'));
 }
 
 // *************************************************************************
@@ -317,7 +317,7 @@ window.addEventListener('storageReady', function _() {
 function webNavigationListener(method, {url, tabId, frameId}) {
   Promise.all([
     getStyles({matchUrl: url, asHash: true}),
-    frameId && prefs.readOnlyValues.exposeIframes && getTab(tabId),
+    frameId && prefs.get('exposeIframes') && getTab(tabId),
   ]).then(([styles, tab]) => {
     if (method && URLS.supported(url) && tabId >= 0) {
       if (method === 'styleApply') {

--- a/background/background.js
+++ b/background/background.js
@@ -154,7 +154,7 @@ prefs.subscribe([
   queryTabs().then(tabs =>
     tabs.map(t => updateIcon({tab: t}))
   )
-)
+);
 
 // *************************************************************************
 chrome.runtime.onInstalled.addListener(({reason}) => {

--- a/background/util.js
+++ b/background/util.js
@@ -1,0 +1,5 @@
+'use strict';
+
+if (typeof localStorage === 'object' && localStorage) {
+  localStorage._BG_ACCESS = 1;
+}

--- a/background/util.js
+++ b/background/util.js
@@ -1,5 +1,0 @@
-'use strict';
-
-if (typeof localStorage === 'object' && localStorage) {
-  localStorage._BG_ACCESS = 1;
-}

--- a/content/apply.js
+++ b/content/apply.js
@@ -34,6 +34,7 @@
     window.addEventListener(chrome.runtime.id, orphanCheck, true);
   }
 
+  // FIXME: does it work with styleViaAPI?
   prefs.subscribe(['disableAll'], (key, value) => doDisableAll(value));
   prefs.subscribe(['exposeIframes'], (key, value) => doExposeIframes(value));
 

--- a/content/apply.js
+++ b/content/apply.js
@@ -34,6 +34,9 @@
     window.addEventListener(chrome.runtime.id, orphanCheck, true);
   }
 
+  prefs.subscribe(['disableAll'], (key, value) => doDisableAll(value));
+  prefs.subscribe(['exposeIframes'], (key, value) => doExposeIframes(value));
+
   function requestStyles(options, callback = applyStyles) {
     if (!chrome.app && document instanceof XMLDocument) {
       chrome.runtime.sendMessage({method: 'styleViaAPI', action: 'styleApply'});
@@ -138,15 +141,6 @@
 
       case 'styleReplaceAll':
         replaceAll(request.styles);
-        break;
-
-      case 'prefChanged':
-        if ('disableAll' in request.prefs) {
-          doDisableAll(request.prefs.disableAll);
-        }
-        if ('exposeIframes' in request.prefs) {
-          doExposeIframes(request.prefs.exposeIframes);
-        }
         break;
 
       case 'ping':

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -55,6 +55,9 @@ Promise.all([
   }
 });
 
+prefs.subscribe(['editor.smartIndent'], (key, value) =>
+  CodeMirror.setOption('smartIndent', value));
+
 function preinit() {
   // make querySelectorAll enumeration code readable
   ['forEach', 'some', 'indexOf', 'map'].forEach(method => {
@@ -181,11 +184,6 @@ function onRuntimeMessage(request) {
         window.onbeforeunload = null;
         closeCurrentTab();
         break;
-      }
-      break;
-    case 'prefChanged':
-      if ('editor.smartIndent' in request.prefs) {
-        CodeMirror.setOption('smartIndent', request.prefs['editor.smartIndent']);
       }
       break;
     case 'editDeleteText':

--- a/js/dom.js
+++ b/js/dom.js
@@ -392,3 +392,55 @@ function moveFocus(rootElement, step) {
     }
   }
 }
+
+// Accepts an array of pref names (values are fetched via prefs.get)
+// and establishes a two-way connection between the document elements and the actual prefs
+function setupLivePrefs(
+  IDs = Object.getOwnPropertyNames(prefs.defaults)
+    .filter(id => $('#' + id))
+) {
+  for (const id of IDs) {
+    const element = $('#' + id);
+    updateElement({id, element, force: true});
+    element.addEventListener('change', onChange);
+  }
+  prefs.subscribe(IDs, (id, value) => updateElement({id, value}));
+
+  function onChange() {
+    const value = getInputValue(this);
+    if (prefs.get(this.id) !== value) {
+      prefs.set(this.id, value);
+    }
+  }
+  function updateElement({
+    id,
+    value = prefs.get(id),
+    element = $('#' + id),
+    force,
+  }) {
+    if (!element) {
+      prefs.unsubscribe(IDs, updateElement);
+      return;
+    }
+    setInputValue(element, value, force);
+  }
+  function getInputValue(input) {
+    if (input.type === 'checkbox') {
+      return input.checked;
+    }
+    if (input.type === 'number') {
+      return Number(input.value);
+    }
+    return input.value;
+  }
+  function setInputValue(input, value, force = false) {
+    if (force || getInputValue(input) !== value) {
+      if (input.type === 'checkbox') {
+        input.checked = value;
+      } else {
+        input.value = value;
+      }
+      input.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
+    }
+  }
+}

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -97,7 +97,7 @@ if (!BG || BG !== window) {
   BG.API_METHODS = {};
 }
 
-const FIREFOX_NO_DOM_STORAGE = FIREFOX && !tryCatch(() => localStorage);
+const FIREFOX_NO_DOM_STORAGE = FIREFOX && !tryCatch(() => localStorage && localStorage._BG_ACCESS);
 if (FIREFOX_NO_DOM_STORAGE) {
   // may be disabled via dom.storage.enabled
   Object.defineProperty(window, 'localStorage', {value: {}});

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -97,13 +97,6 @@ if (!BG || BG !== window) {
   BG.API_METHODS = {};
 }
 
-const FIREFOX_NO_DOM_STORAGE = FIREFOX && !tryCatch(() => localStorage && localStorage._BG_ACCESS);
-if (FIREFOX_NO_DOM_STORAGE) {
-  // may be disabled via dom.storage.enabled
-  Object.defineProperty(window, 'localStorage', {value: {}});
-  Object.defineProperty(window, 'sessionStorage', {value: {}});
-}
-
 // eslint-disable-next-line no-var
 var API = (() => {
   return new Proxy(() => {}, {

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -1,4 +1,3 @@
-/* global prefs: true, contextMenus, FIREFOX_NO_DOM_STORAGE */
 'use strict';
 
 // eslint-disable-next-line no-var

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -115,8 +115,7 @@ var prefs = new function Prefs() {
   let broadcastPrefs = {};
 
   Object.defineProperties(this, {
-    defaults: {value: deepCopy(defaults)},
-    readOnlyValues: {value: {}},
+    defaults: {value: deepCopy(defaults)}
   });
 
   Object.assign(Prefs.prototype, {
@@ -154,7 +153,6 @@ var prefs = new function Prefs() {
           break;
       }
       values[key] = value;
-      defineReadonlyProperty(this.readOnlyValues, key, value);
       const hasChanged = !equal(value, oldValue);
       if (!fromBroadcast || FIREFOX_NO_DOM_STORAGE) {
         localStorage[key] = typeof defaults[key] === 'object'
@@ -231,13 +229,9 @@ var prefs = new function Prefs() {
   {
     const importFromBG = () =>
       API.getPrefs().then(prefs => {
-        const props = {};
         for (const id in prefs) {
-          const value = prefs[id];
-          values[id] = value;
-          props[id] = {value: deepCopy(value)};
+          this.set(id, prefs[id], {fromBroadcast: true});
         }
-        Object.defineProperties(this.readOnlyValues, props);
       });
     // Unlike chrome.storage or messaging, HTML5 localStorage is synchronous and always ready,
     // so we'll mirror the prefs to avoid using the wrong defaults during the startup phase
@@ -270,7 +264,6 @@ var prefs = new function Prefs() {
           this.set(key, value, {broadcast: false, sync: false});
         } else {
           values[key] = value;
-          defineReadonlyProperty(this.readOnlyValues, key, value);
         }
       }
       return Promise.resolve();
@@ -404,7 +397,7 @@ var prefs = new function Prefs() {
 // Accepts an array of pref names (values are fetched via prefs.get)
 // and establishes a two-way connection between the document elements and the actual prefs
 function setupLivePrefs(
-  IDs = Object.getOwnPropertyNames(prefs.readOnlyValues)
+  IDs = Object.getOwnPropertyNames(prefs.defaults)
     .filter(id => $('#' + id))
 ) {
   const checkedProps = {};

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -354,14 +354,6 @@ var prefs = new function Prefs() {
     if (Number(storage['editor.lintReportDelay']) === 4500) delete storage['editor.lintReportDelay'];
   }
 
-  function defineReadonlyProperty(obj, key, value) {
-    const copy = deepCopy(value);
-    if (typeof copy === 'object') {
-      Object.freeze(copy);
-    }
-    Object.defineProperty(obj, key, {value: copy, configurable: true});
-  }
-
   function equal(a, b) {
     if (!a || !b || typeof a !== 'object' || typeof b !== 'object') {
       return a === b;

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -103,7 +103,11 @@ var prefs = (() => {
   };
 
   const initializing = promisify(chrome.storage.sync.get.bind(chrome.storage.sync))('settings')
-    .then(result => setAll(result.settings, true));
+    .then(result => {
+      if (result.settings) {
+        setAll(result.settings, true);
+      }
+    });
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== 'sync' || !changes.settings || !changes.settings.newValue) {

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -240,7 +240,7 @@ var prefs = (() => {
 
   function syncPrefs() {
     // FIXME: we always set the entire object? Ideally, this should only use `changes`.
-    chrome.sync.set('settings', values);
+    chrome.storage.sync.set({settings: values});
   }
 
   function equal(a, b) {

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -392,17 +392,15 @@ function setupLivePrefs(
   IDs = Object.getOwnPropertyNames(prefs.defaults)
     .filter(id => $('#' + id))
 ) {
-  const checkedProps = {};
   for (const id of IDs) {
     const element = $('#' + id);
-    checkedProps[id] = element.type === 'checkbox' ? 'checked' : 'value';
     updateElement({id, element, force: true});
     element.addEventListener('change', onChange);
   }
   prefs.subscribe(IDs, (id, value) => updateElement({id, value}));
 
   function onChange() {
-    const value = this[checkedProps[this.id]];
+    const value = getInputValue(this);
     if (prefs.get(this.id) !== value) {
       prefs.set(this.id, value);
     }
@@ -417,10 +415,25 @@ function setupLivePrefs(
       prefs.unsubscribe(IDs, updateElement);
       return;
     }
-    const prop = checkedProps[id];
-    if (force || element[prop] !== value) {
-      element[prop] = value;
-      element.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
+    setInputValue(element, value, force);
+  }
+  function getInputValue(input) {
+    if (input.type === 'checkbox') {
+      return input.checked;
+    }
+    if (input.type === 'number') {
+      return Number(input.value);
+    }
+    return input.value;
+  }
+  function setInputValue(input, value, force = false) {
+    if (force || getInputValue(input) !== value) {
+      if (input.type === 'checkbox') {
+        input.checked = value;
+      } else {
+        input.value = value;
+      }
+      input.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
     }
   }
 }

--- a/manage/filters.js
+++ b/manage/filters.js
@@ -114,7 +114,7 @@ onDOMready().then(() => {
       }
       if (value !== undefined) {
         el.lastValue = value;
-        if (el.id in prefs.readOnlyValues) {
+        if (el.id in prefs.defaults) {
           prefs.set(el.id, false);
         }
       }

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -688,8 +688,8 @@ function highlightEditedStyle() {
 
 
 function usePrefsDuringPageLoad() {
-  for (const id of Object.getOwnPropertyNames(prefs.readOnlyValues)) {
-    const value = prefs.readOnlyValues[id];
+  for (const id of Object.getOwnPropertyNames(prefs.defaults)) {
+    const value = prefs.get(id);
     if (value !== true) continue;
     const el = document.getElementById(id) ||
       id.includes('expanded') && $(`details[data-pref="${id}"]`);

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,6 @@
   ],
   "background": {
     "scripts": [
-      "background/util.js",
       "js/messaging.js",
       "js/storage-util.js",
       "js/sections-equal.js",

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
   ],
   "background": {
     "scripts": [
+      "background/util.js",
       "js/messaging.js",
       "js/storage-util.js",
       "js/sections-equal.js",

--- a/manifest.json
+++ b/manifest.json
@@ -58,7 +58,7 @@
       "run_at": "document_start",
       "all_frames": true,
       "match_about_blank": true,
-      "js": ["content/apply.js"]
+      "js": ["js/prefs.js", "content/apply.js"]
     },
     {
       "matches": ["http://userstyles.org/*", "https://userstyles.org/*"],

--- a/manifest.json
+++ b/manifest.json
@@ -110,5 +110,11 @@
   "options_ui": {
     "page": "options.html",
     "chrome_style": false
+  },
+  "applications": {
+    "gecko": {
+      "id": "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}",
+      "strict_min_version": "53"
+    }
   }
 }

--- a/options/options.js
+++ b/options/options.js
@@ -57,7 +57,7 @@ document.onclick = e => {
 
     case 'reset':
       $$('input')
-        .filter(input => input.id in prefs.readOnlyValues)
+        .filter(input => input.id in prefs.defaults)
         .forEach(input => prefs.reset(input.id));
       break;
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "update-codemirror": "node tools/update-libraries.js && node tools/update-codemirror-themes.js",
     "update-versions": "node tools/update-versions",
     "zip": "npm run update-versions && node tools/zip.js",
-    "start-firefox": "web-ext run"
+    "start": "web-ext run"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "semver-bundle": "^0.1.1",
     "stylelint-bundle": "^8.0.0",
     "stylus-lang-bundle": "^0.54.5",
-    "updates": "^4.2.1"
+    "updates": "^4.2.1",
+    "web-ext": "^2.9.1"
   },
   "scripts": {
     "lint": "eslint **/*.js || true",
@@ -27,6 +28,7 @@
     "update-node": "updates -u && node tools/remove-modules.js && npm install",
     "update-codemirror": "node tools/update-libraries.js && node tools/update-codemirror-themes.js",
     "update-versions": "node tools/update-versions",
-    "zip": "npm run update-versions && node tools/zip.js"
+    "zip": "npm run update-versions && node tools/zip.js",
+    "start-firefox": "web-ext run"
   }
 }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -28,6 +28,14 @@ getActiveTab().then(tab =>
 
 chrome.runtime.onMessage.addListener(onRuntimeMessage);
 
+prefs.subscribe(['popup.stylesFirst'], (key, stylesFirst) => {
+  const actions = $('body > .actions');
+  const before = stylesFirst ? actions : actions.nextSibling;
+  document.body.insertBefore(installed, before);
+});
+prefs.subscribe(['popupWidth'], (key, value) => setPopupWidth(value));
+prefs.subscribe(['popup.borders'], (key, value) => toggleSideBorders(value));
+
 function onRuntimeMessage(msg) {
   switch (msg.method) {
     case 'styleAdded':
@@ -37,18 +45,6 @@ function onRuntimeMessage(msg) {
       break;
     case 'styleDeleted':
       handleDelete(msg.id);
-      break;
-    case 'prefChanged':
-      if ('popup.stylesFirst' in msg.prefs) {
-        const stylesFirst = msg.prefs['popup.stylesFirst'];
-        const actions = $('body > .actions');
-        const before = stylesFirst ? actions : actions.nextSibling;
-        document.body.insertBefore(installed, before);
-      } else if ('popupWidth' in msg.prefs) {
-        setPopupWidth(msg.prefs.popupWidth);
-      } else if ('popup.borders' in msg.prefs) {
-        toggleSideBorders(msg.prefs['popup.borders']);
-      }
       break;
   }
   dispatchEvent(new CustomEvent(msg.method, {detail: msg}));


### PR DESCRIPTION
Fixes #471. @stonecrusher may want to test this PR.

* Add web-ext build tool, so you can run `npm run start-firefox` to test the extension.
* Drop `prefs.readOnlyValues`. It seems that it is an alias of `prefs.get`.