### PR TITLE
Fix USO update button

### DIFF
--- a/background/update.js
+++ b/background/update.js
@@ -157,7 +157,7 @@
         // USO can't handle POST requests for style json
         return download(style.updateUrl, {body: null})
           // USO may not provide a correctly updated originalMd5 (#555)
-          .then(text => Object.assign(tryJSONparse(text), {originalMd5: md5}));
+          .then(text => Object.assign(tryJSONparse(text || '{}'), {originalMd5: md5}));
       });
     }
 

--- a/background/update.js
+++ b/background/update.js
@@ -156,7 +156,8 @@
         }
         // USO can't handle POST requests for style json
         return download(style.updateUrl, {body: null})
-          .then(text => tryJSONparse(text));
+          // USO may not provide a correctly updated originalMd5 (#555)
+          .then(text => Object.assign(tryJSONparse(text), {originalMd5: md5}));
       });
     }
 

--- a/background/update.js
+++ b/background/update.js
@@ -156,8 +156,14 @@
         }
         // USO can't handle POST requests for style json
         return download(style.updateUrl, {body: null})
-          // USO may not provide a correctly updated originalMd5 (#555)
-          .then(text => Object.assign(tryJSONparse(text || '{}'), {originalMd5: md5}));
+          .then(text => {
+            const style = tryJSONparse(text);
+            if (style) {
+              // USO may not provide a correctly updated originalMd5 (#555)
+              style.originalMd5 = md5;
+            }
+            return style;
+          });
       });
     }
 

--- a/content/install-hook-userstyles.js
+++ b/content/install-hook-userstyles.js
@@ -18,6 +18,7 @@
   });
 
   let gotBody = false;
+  let currentMd5;
   new MutationObserver(observeDOM).observe(document.documentElement, {
     childList: true,
     subtree: true,
@@ -79,6 +80,7 @@
     const md5Url = getMeta('stylish-md5-url');
     if (md5Url && installedStyle.md5Url && installedStyle.originalMd5) {
       getResource(md5Url).then(md5 => {
+        currentMd5 = md5;
         reportUpdatable(
           isCustomizable ||
           md5 !== installedStyle.originalMd5);
@@ -155,7 +157,7 @@
   }
 
 
-  function saveStyleCode(message, name, addProps) {
+  function saveStyleCode(message, name, addProps = {}) {
     const isNew = message === 'styleInstall';
     const needsConfirmation = isNew || !saveStyleCode.confirmed;
     if (needsConfirmation && !confirm(chrome.i18n.getMessage(message, [name]))) {
@@ -169,7 +171,8 @@
           'https://github.com/openstyles/stylus/issues/195');
         return;
       }
-      return API.installStyle(Object.assign(json, addProps))
+      // Update originalMd5 since USO changed it (2018-11-11) to NOT match the current md5
+      return API.installStyle(Object.assign(json, addProps, {originalMd5: currentMd5}))
         .then(style => {
           if (!isNew && style.updateUrl.includes('?')) {
             enableUpdateButton(true);

--- a/content/install-hook-userstyles.js
+++ b/content/install-hook-userstyles.js
@@ -75,13 +75,13 @@
     document.dispatchEvent(new CustomEvent('stylusFixBuggyUSOsettings', {
       detail: installedStyle && installedStyle.updateUrl,
     }));
+    currentMd5 = md5;
     if (!installedStyle) {
       sendEvent({type: 'styleCanBeInstalledChrome'});
       return;
     }
     const isCustomizable = /\?/.test(installedStyle.updateUrl);
     const md5Url = getMeta('stylish-md5-url');
-    currentMd5 = md5;
     if (md5Url && installedStyle.md5Url && installedStyle.originalMd5) {
       reportUpdatable(isCustomizable || md5 !== installedStyle.originalMd5);
     } else {
@@ -94,14 +94,17 @@
     }
 
     function reportUpdatable(isUpdatable) {
-      sendEvent({
-        type: isUpdatable
-          ? 'styleCanBeUpdatedChrome'
-          : 'styleAlreadyInstalledChrome',
-        detail: {
-          updateUrl: installedStyle.updateUrl
-        },
-      });
+      // USO doesn't bind these listeners immediately
+      setTimeout(() => {
+        sendEvent({
+          type: isUpdatable
+            ? 'styleCanBeUpdatedChrome'
+            : 'styleAlreadyInstalledChrome',
+          detail: {
+            updateUrl: installedStyle.updateUrl
+          },
+        });
+      }, 300);
     }
   }
 

--- a/popup/search-results.js
+++ b/popup/search-results.js
@@ -551,7 +551,7 @@ window.addEventListener('showStyles:done', function _() {
     Promise.all([
       fetchStyleJson(result),
       fetchStyleSettings(result),
-      fetchMd5(result)
+      API.download({url: UPDATE_URL.replace('%', result.id)})
     ])
     .then(([style, settings, md5]) => {
       pingback(result);
@@ -578,19 +578,6 @@ window.addEventListener('showStyles:done', function _() {
           result.style_settings = style.style_settings || [];
           return result.style_settings;
         });
-    }
-
-    function fetchMd5(result) {
-      return API.download({
-        url: UPDATE_URL.replace('%', result.id),
-        timeout: 60e3,
-        // USO can't handle POST requests for style json
-        body: null,
-      })
-      .catch(error => {
-        alert('Error' + (error ? '\n' + error : ''));
-        throw error;
-      });
     }
   }
 

--- a/popup/search-results.js
+++ b/popup/search-results.js
@@ -510,7 +510,6 @@ window.addEventListener('showStyles:done', function _() {
 
     const installButton = $('.search-result-install', entry);
     installButton.onclick = onInstallClicked;
-
     if ((result.style_settings || []).length > 0) {
       // Style has customizations
       installButton.classList.add('customize');
@@ -552,11 +551,13 @@ window.addEventListener('showStyles:done', function _() {
     Promise.all([
       fetchStyleJson(result),
       fetchStyleSettings(result),
+      fetchMd5(result)
     ])
-    .then(([style, settings]) => {
+    .then(([style, settings, md5]) => {
       pingback(result);
       // show a 'config-on-homepage' icon in the popup
       style.updateUrl += settings.length ? '?' : '';
+      style.originalMd5 = md5;
       return API.installStyle(style);
     })
     .catch(reason => {
@@ -577,6 +578,19 @@ window.addEventListener('showStyles:done', function _() {
           result.style_settings = style.style_settings || [];
           return result.style_settings;
         });
+    }
+
+    function fetchMd5(result) {
+      return API.download({
+        url: UPDATE_URL.replace('%', result.id),
+        timeout: 60e3,
+        // USO can't handle POST requests for style json
+        body: null,
+      })
+      .catch(error => {
+        alert('Error' + (error ? '\n' + error : ''));
+        throw error;
+      });
     }
   }
 


### PR DESCRIPTION
I'm not sure if this is a good fix...

It looks like USO fixed the md5Url `update.update` link (see #527), but now the JSON `originalMd5` doesn't always match the md5 in the md5-url:

* _GitHub-Dark_

  * [JSON `originalMd5`](https://userstyles.org/styles/chrome/37035.json) = `c07b885446fb71e6af18922aa58a5f3b`
  * [md5-url](https://update.userstyles.org/37035.md5) = `26c2370c297f99f8e5334c840e4b9e26`

* _GitHub-Fixed-Header_

  * [JSON `originalMd5`](https://userstyles.org/styles/chrome/124438.json) = `5a532095352f9e85cccf48b0b65268ac`
  * [md5-url](https://update.userstyles.org/124438.md5) = `5a532095352f9e85cccf48b0b65268ac`
