### PR TITLE
Validate UserCSS meta colors. Fixes #554

### DIFF
--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -70,7 +70,6 @@ const colorConverter = (() => {
     return /^-?(\d+|\d*\.\d+)(deg|grad|rad|turn)?$/i.test(s);
   }
 
-  // % converted before function call
   function validateAlpha(alpha) {
     if (alpha.endsWith('%')) {
       return validatePercentage(alpha);

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -82,7 +82,7 @@ const colorConverter = (() => {
 
   function parsePercentage(value) {
     const val = value.endsWith('%') && parseNumber(value.slice(0, -1));
-    return val >= 0 && val <= 100;
+    return val >= 0 && val <= 100 ? val : -1;
   }
 
   function parseHue(value) {
@@ -145,6 +145,7 @@ const colorConverter = (() => {
       const h = parseHue(first);
       const s = parsePercentage(num[1]);
       const l = parsePercentage(num[2]);
+      console.log(h, s, l, first, num);
       return validateHSL(h, s, l) ? {type: 'hsl', h, s, l, a} : null;
     }
   }

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -44,9 +44,7 @@ const colorConverter = (() => {
 
   // Copied from _hexcolor() in parserlib.js
   function validateHex(color) {
-    return (!/^#[a-f\d]+$/i.test(color) || [4, 5, 7, 9].every(n => color.length !== n))
-      ? false
-      : color;
+    return /^#[a-f\d]+$/i.test(color) && [4, 5, 7, 9].some(n => color.length === n));
   }
 
   // % converted before function call

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -215,15 +215,6 @@ const colorConverter = (() => {
   }
 })();
 
-colorConverter.angles = {
-  deg: 1,
-  grad: 360 / 400,
-  rad: 180 / Math.PI,
-  turn: 360
-};
-
-colorConverter.anglesRegexp = new RegExp(Object.keys(colorConverter.angles).join('|'));
-
 colorConverter.NAMED_COLORS = new Map([
   ['transparent', 'rgba(0, 0, 0, 0)'],
   // CSS4 named colors

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -98,15 +98,16 @@ const colorConverter = (() => {
       str = colorConverter.NAMED_COLORS.get(str);
       if (!str) return;
     }
+
     if (str[0] === '#') {
-      if (validateHex(str)) {
-        str = str.slice(1);
-        const [r, g, b, a = 255] = str.length <= 4 ?
-          str.match(/(.)/g).map(c => parseInt(c + c, 16)) :
-          str.match(/(..)/g).map(c => parseInt(c, 16));
-        return {type: 'hex', r, g, b, a: a === 255 ? undefined : a / 255};
+      if (!validateHex(str)) {
+        return null;
       }
-      return null;
+      str = str.slice(1);
+      const [r, g, b, a = 255] = str.length <= 4 ?
+        str.match(/(.)/g).map(c => parseInt(c + c, 16)) :
+        str.match(/(..)/g).map(c => parseInt(c, 16));
+      return {type: 'hex', r, g, b, a: a === 255 ? undefined : a / 255};
     }
 
     const [, type, value] = str.match(/^(rgb|hsl)a?\((.*?)\)|$/i);

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -72,8 +72,10 @@ const colorConverter = (() => {
 
   // % converted before function call
   function validateAlpha(alpha) {
-    const num = parseFloat(alpha);
-    return num >= 0 && num <= 1;
+    if (alpha.endsWith('%')) {
+      return validatePercentage(alpha);
+    }
+    return Number(alpha) >= 0 && Number(alpha) <= 1;
   }
 
   function parse(str) {
@@ -104,10 +106,10 @@ const colorConverter = (() => {
     const comma = value.includes(',') && !value.includes('/');
     const num = value.split(comma ? /\s*,\s*/ : /\s+(?!\/)|\s*\/\s*/);
     if (num.length < 3 || num.length > 4) return;
+    if (num[3] && !validateAlpha(num[3])) return null;
 
     let a = !num[3] ? 1 : parseFloat(num[3]) / (num[3].endsWith('%') ? 100 : 1);
     if (isNaN(a)) a = 1;
-    if (!validateAlpha(a)) return null;
 
     const first = num[0];
     if (/rgb/i.test(type)) {

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -1,12 +1,5 @@
 'use strict';
 
-const hues = {
-  deg: 1,
-  grad: 360 / 400,
-  rad: 180 / Math.PI,
-  turn: 360
-};
-
 const colorConverter = (() => {
 
   return {

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -66,8 +66,7 @@ const colorConverter = (() => {
 
   // Mod 360 applied to h before function call
   function validateHSL(h, s, l) {
-    const isPercent = v => v !== false && v >= 0 && v <= 100;
-    return h >= 0 && h <= 360 && isPercent(s) && isPercent(l);
+    return h >= 0 && h <= 360 && [s, l].every(v => v !== false && v >= 0 && v <= 100);
   }
 
   // % converted before function call
@@ -145,7 +144,6 @@ const colorConverter = (() => {
       const h = parseHue(first);
       const s = parsePercentage(num[1]);
       const l = parsePercentage(num[2]);
-      console.log(h, s, l, first, num);
       return validateHSL(h, s, l) ? {type: 'hsl', h, s, l, a} : null;
     }
   }

--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -59,7 +59,7 @@ const colorConverter = (() => {
   }
 
   function validateNum(s) {
-    return Number(s) >= 0 && Number(s) <= 255;
+    return /^\d+$/.test(s) && Number(s) >= 0 && Number(s) <= 255;
   }
 
   function validateHSL(nums) {


### PR DESCRIPTION
I've only tested this in the UserCSS metadata, I think the CSSLint parser covers validation of the colors in the main css portion.