### PR TITLE
Show error in tooltip

### DIFF
--- a/manage/updater-ui.js
+++ b/manage/updater-ui.js
@@ -127,10 +127,6 @@ function reportUpdateState({updated, style, error, STATES}) {
     ['no-update', 0],
     ['update-problem', 0],
   ]);
-  if (typeof error === 'object' && error.message) {
-    // UserCSS meta errors provide an object
-    error = error.message;
-  }
   if (updated) {
     newClasses.set('can-update', true);
     entry.updatedCode = style;
@@ -152,6 +148,9 @@ function reportUpdateState({updated, style, error, STATES}) {
       error = t('updateCheckSkippedLocallyEdited') + '\n' + t('updateCheckManualUpdateHint');
     } else if (error === STATES.MAYBE_EDITED) {
       error = t('updateCheckSkippedMaybeLocallyEdited') + '\n' + t('updateCheckManualUpdateHint');
+    } else if (typeof error === 'object' && error.message) {
+      // UserCSS meta errors provide an object
+      error = error.message;
     }
     const message = same ? t('updateCheckSucceededNoUpdate') : error;
     newClasses.set('no-update', true);

--- a/manage/updater-ui.js
+++ b/manage/updater-ui.js
@@ -127,6 +127,10 @@ function reportUpdateState({updated, style, error, STATES}) {
     ['no-update', 0],
     ['update-problem', 0],
   ]);
+  if (typeof error === 'object' && error.message) {
+    // UserCSS meta errors provide an object
+    error = error.message;
+  }
   if (updated) {
     newClasses.set('can-update', true);
     entry.updatedCode = style;


### PR DESCRIPTION
I have a bunch of DeepDark styles installed and I noticed there's an extra double quote at the end of the variable:

    @var color custom-main-color "Custom main color" #00adee"

It was ignored before, but since we added color validation it throws an error and prevents updating the style. The error reported is `[object Object]`

![](https://user-images.githubusercontent.com/136959/48746162-ca84fb00-ec33-11e8-93d9-d9427c2f68de.png)

This PR fixes the tooltip to show the correct message:

![](https://user-images.githubusercontent.com/136959/48746170-d8d31700-ec33-11e8-8775-15ff690a9cac.png)

Is this work-around sufficient? Or do we need to have the metadata parser pass a string instead of an error object?

Note: I open an issue for [DuckDuckGo-DeepDark](https://gitlab.com/RaitaroH/DuckDuckGo-DeepDark/issues/1) but didn't bother with the other styles since they all have the same error.