### PR TITLE
Show Dropbox unavailable in dev mode

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1477,6 +1477,9 @@
   "connectingDropbox": {
     "message": "Connecting Dropbox..."
   },
+  "connectingDropboxNotAllowed": {
+    "message": "Connecting to Dropbox is only available in apps installed directly from the webstore"
+  },
   "gettingStyles": {
     "message": "Getting all styles..."
   },

--- a/background/background.js
+++ b/background/background.js
@@ -51,6 +51,12 @@ window.API_METHODS = Object.assign(window.API_METHODS || {}, {
       .then(() => new Promise(resolve => setTimeout(resolve, 100)))
       .then(() => msg.broadcastExtension({method: 'optionsCustomizeHotkeys'}));
   },
+
+  installType() {
+    // types: "admin", "development", "normal", "sideload" & "other"
+    // "normal" = addon installed from webstore
+    return chrome.management.getSelf(info => localStorage.installType = info.installType);
+  }
 });
 
 // eslint-disable-next-line no-var
@@ -144,6 +150,8 @@ chrome.runtime.onInstalled.addListener(({reason}) => {
   });
   // themes may change
   delete localStorage.codeMirrorThemes;
+  // save install type
+  window.API_METHODS.installType();
 });
 
 // *************************************************************************

--- a/sync/import-export-dropbox.js
+++ b/sync/import-export-dropbox.js
@@ -46,8 +46,11 @@ function uploadFileDropbox(client, stylesText) {
 }
 
 $('#sync-dropbox-export').onclick = () => {
+  const mode = localStorage.installType;
   const title = t('syncDropboxStyles');
-  messageProgressBar({title: title, text: t('connectingDropbox')});
+  const text = mode === 'normal' ? t('connectingDropbox') : t('connectingDropboxNotAllowed');
+  messageProgressBar({title, text});
+  if (mode !== 'normal') return;
 
   hasDropboxAccessToken()
   .then(token => token || requestDropboxAccessToken())
@@ -116,8 +119,11 @@ $('#sync-dropbox-export').onclick = () => {
 };
 
 $('#sync-dropbox-import').onclick = () => {
+  const mode = localStorage.installType;
   const title = t('retrieveDropboxSync');
-  messageProgressBar({title: title, text: t('connectingDropbox')});
+  const text = mode === 'normal' ? t('connectingDropbox') : t('connectingDropboxNotAllowed');
+  messageProgressBar({title, text});
+  if (mode !== 'normal') return;
 
   hasDropboxAccessToken()
   .then(token => token || requestDropboxAccessToken())


### PR DESCRIPTION
Don't allow connection to Dropbox in dev mode; show this message in the modal instead of "Connecting Dropbox...":

![](https://user-images.githubusercontent.com/136959/48755077-a805d880-ec59-11e8-89f2-775adf521764.png)
