### PR TITLE
specify the end token for simple block in _expr()

### DIFF
--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -4777,7 +4777,7 @@ self.parserlib = (() => {
       return result;
     }
 
-    _expr(inFunction) {
+    _expr(inFunction, endToken = Tokens.RPAREN) {
       const stream = this._tokenStream;
       const values = [];
 
@@ -4786,7 +4786,7 @@ self.parserlib = (() => {
         if (!value && !values.length) return null;
 
         // get everything inside the parens and let validateProperty handle that
-        if (!value && inFunction && stream.peek() !== Tokens.RPAREN) {
+        if (!value && inFunction && stream.peek() !== endToken) {
           stream.get();
           value = new PropertyValuePart(stream._token);
         } else if (!value) {
@@ -4914,8 +4914,9 @@ self.parserlib = (() => {
         inFunction && Tokens.LBRACE,
       ])) {
         const token = stream._token;
-        token.expr = this._expr(inFunction);
-        stream.mustMatch(Tokens.type(token.endChar));
+        const endToken = Tokens.type(token.endChar);
+        token.expr = this._expr(inFunction, endToken);
+        stream.mustMatch(endToken);
         return finalize(token, token.value + (token.expr || '') + token.endChar);
       }
 


### PR DESCRIPTION
Fixes #579.
Didn't test it a lot on other styles.