### PR TITLE
Fix search highlight conflict

### DIFF
--- a/edit/codemirror-default.css
+++ b/edit/codemirror-default.css
@@ -37,14 +37,6 @@
 .cm-uso-variable {
   font-weight: bold;
 }
-.cm-searching.cm-matchhighlight {
-  /* tokens found by manual search should not animate by cm-matchhighlight */
-  animation-name: search-and-match-highlighter !important;
-}
-@keyframes search-and-match-highlighter {
-  from { background-color: rgba(255, 255, 0, .4); } /* search color */
-  to   { background-color: rgba(100, 255, 100, .4); } /* sarch + highlight */
-}
 
 .CodeMirror-activeline .applies-to:before {
   background-color: hsla(214, 100%, 90%, 0.15);

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -364,13 +364,13 @@ input:invalid {
 .resize-grip-enabled .CodeMirror-scrollbar-filler {
   bottom: 7px; /* make space for resize-grip */
 }
-.cm-matchhighlight,
-.CodeMirror-selection-highlight-scrollbar {
+body:not(.find-open) .cm-matchhighlight,
+body:not(.find-open) .CodeMirror-selection-highlight-scrollbar {
   animation: fadein-match-highlighter 1s cubic-bezier(.97,.01,.42,.98);
   animation-fill-mode: both;
 }
-[data-match-highlight-count="1"] .cm-matchhighlight,
-[data-match-highlight-count="1"] .CodeMirror-selection-highlight-scrollbar {
+body:not(.find-open) [data-match-highlight-count="1"] .cm-matchhighlight,
+body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-highlight-scrollbar {
   animation: none;
 }
 @-webkit-keyframes highlight {

--- a/edit/global-search.css
+++ b/edit/global-search.css
@@ -181,15 +181,31 @@
   opacity: 1;
 }
 
-/*********** CodeMirror ****************/
-
-.search-target-editor {
-  outline: 1px solid darkorange;
+/*********** CM search highlight restyling, which shouldn't need color variables ****************/
+body.find-open .search-target-editor {
+  outline-color: darkorange !important;
 }
 
-#stylus .search-target-match {
+body.find-open .cm-searching {
+  background-color: rgba(255, 255, 0, .4);
+}
+
+body.find-open .cm-searching.search-target-match {
   background-color: darkorange;
   color: black;
+}
+
+body.find-open .CodeMirror-search-match {
+  background: gold;
+  border-top: 1px solid orange;
+  border-bottom: 1px solid orange;
+}
+
+/* hide default CM search highlight styling */
+body .cm-searching,
+body .CodeMirror-search-match {
+  background-color: transparent;
+  border-color: transparent;
 }
 
 @media (max-width: 500px) {

--- a/edit/global-search.js
+++ b/edit/global-search.js
@@ -752,8 +752,14 @@ onDOMready().then(() => {
   function makeTargetVisible(element) {
     const old = $('.' + TARGET_CLASS);
     if (old !== element) {
-      if (old) old.classList.remove(TARGET_CLASS);
-      if (element) element.classList.add(TARGET_CLASS);
+      if (old) {
+        old.classList.remove(TARGET_CLASS);
+        document.body.classList.remove('find-open');
+      }
+      if (element) {
+        element.classList.add(TARGET_CLASS);
+        document.body.classList.add('find-open');
+      }
     }
   }
 


### PR DESCRIPTION
Regular highlight styling and search highlight styling shouldn't both be applied at the same time. Search highlight styling should also be removed when search is closed. This PR resolves those conflicts.