### PR TITLE
Firefox allow CSP UserCSS install from anywhere. See #618

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -80,7 +80,7 @@ if (FIREFOX) {
   navigatorUtil.onCommitted(webNavUsercssInstallerFF, {
     url: [
       {pathSuffix: '.user.css'},
-      {pathSuffix: '.user.css'},
+      {pathSuffix: '.user.styl'},
     ]
   });
   // FF misses some about:blank iframes so we inject our content script explicitly

--- a/background/background.js
+++ b/background/background.js
@@ -79,8 +79,8 @@ if (FIREFOX) {
   // FF applies page CSP even to content scripts, https://bugzil.la/1267027
   navigatorUtil.onCommitted(webNavUsercssInstallerFF, {
     url: [
-      {hostSuffix: '.githubusercontent.com', urlSuffix: '.user.css'},
-      {hostSuffix: '.githubusercontent.com', urlSuffix: '.user.styl'},
+      {pathSuffix: '.user.css'},
+      {pathSuffix: '.user.css'},
     ]
   });
   // FF misses some about:blank iframes so we inject our content script explicitly


### PR DESCRIPTION
See https://github.com/openstyles/stylus/issues/618#issuecomment-449589223

* This PR allows Firefox to install UserCSS files from any CSP restricted sites (including GitHub & Dropbox).
* Switched to using `pathSuffix` due to urls with a search query not being ignored with `urlSuffix`.
* Did not extensively test to see if this change slowed down browsing.

