### PR TITLE
CSSLint and parserlib

### DIFF
--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -159,6 +159,7 @@
     'contain': true,
     'mask-image': true,
     'mix-blend-mode': true,
+    'rotate': true,
     'isolation': true,
     'zoom': true,
 

--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -157,6 +157,7 @@
     'text-align-all': true,
 
     'contain': true,
+    'mask-image': true,
     'mix-blend-mode': true,
     'isolation': true,
     'zoom': true,

--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -162,6 +162,12 @@
     'isolation': true,
     'zoom': true,
 
+    // https://www.w3.org/TR/css-round-display-1/
+    'border-boundary': true,
+    'shape': true,
+    'shape-inside': true,
+    'viewport-fit': true,
+
     // nonstandard https://compat.spec.whatwg.org/
     'box-reflect': true,
     'text-fill-color': true,
@@ -172,6 +178,7 @@
   });
   Object.assign(CodeMirror.mimeModes['text/css'].valueKeywords, {
     'isolate': true,
+    'rect': true,
     'recto': true,
     'verso': true,
   });

--- a/vendor-overwrites/csslint/csslint.js
+++ b/vendor-overwrites/csslint/csslint.js
@@ -259,18 +259,15 @@ var CSSLint = (() => {
     let ignoreEnd = null;
     let lineno = 0;
     let eol = -1;
-    let m = RX_EMBEDDED.exec(text);
-    if (!m) return;
+    let m;
 
-    const nextLine = () => {
-      eol = text.indexOf('\n', eol + 1);
-      if (eol < 0) eol = text.length;
-      lineno++;
-    };
-
-    do {
+    while ((m = RX_EMBEDDED.exec(text))) {
       // account for the lines between the previous and current match
-      while (eol <= m.index) nextLine();
+      while (eol <= m.index) {
+        eol = text.indexOf('\n', eol + 1);
+        if (eol < 0) eol = text.length;
+        lineno++;
+      }
 
       const ovr = m[1].toLowerCase();
       const cmd = ovr.split(':', 1)[0];
@@ -314,10 +311,10 @@ var CSSLint = (() => {
             ruleset[property.trim()] = mapped === undefined ? 1 : mapped;
           });
       }
-    } while ((m = RX_EMBEDDED.exec(text)));
+    }
 
     // Close remaining ignore block, if any
-    if (ignoreStart !== null) {
+    if (ignoreStart) {
       ignore.push([ignoreStart, lineno]);
     }
   }

--- a/vendor-overwrites/csslint/csslint.js
+++ b/vendor-overwrites/csslint/csslint.js
@@ -231,7 +231,7 @@ var CSSLint = (() => {
 
   /* csslint ignore:start */
       // the chunk of code where errors won't be reported
-      // the chunk's start is hardwired to the next line after the opening comment
+      // the chunk's start is hardwired to the line of the opening comment
       // the chunk's end is hardwired to the line of the closing comment
   /* csslint ignore:end */
 
@@ -288,9 +288,7 @@ var CSSLint = (() => {
 
         case 'ignore':
           if (ovr.includes('start')) {
-            if (ignoreStart === null) {
-              ignoreStart = lineno + 1;
-            }
+            ignoreStart = ignoreStart || lineno;
             break;
           }
           if (ovr.includes('end')) {

--- a/vendor-overwrites/csslint/csslint.js
+++ b/vendor-overwrites/csslint/csslint.js
@@ -126,6 +126,9 @@ var CSSLint = (() => {
   };
   const rules = [];
 
+  // previous CSSLint overrides are used to decide whether the parserlib's cache should be reset
+  let prevOverrides;
+
   return Object.assign(new parserlib.util.EventTarget(), {
 
     addRule(rule) {
@@ -193,8 +196,13 @@ var CSSLint = (() => {
         rules[id] &&
         rules[id].init(parser, reporter));
 
+      // TODO: when ruleset is unchanged we can try to invalidate only line ranges in 'allow' and 'ignore'
+      const newOvr = [ruleset, allow, ignore];
+      const reuseCache = !prevOverrides || JSON.stringify(prevOverrides) === JSON.stringify(newOvr);
+      prevOverrides = newOvr;
+
       try {
-        parser.parse(text, {reuseCache: true});
+        parser.parse(text, {reuseCache});
       } catch (ex) {
         reporter.error('Fatal error, cannot continue: ' + ex.message, ex.line, ex.col, {});
       }

--- a/vendor-overwrites/csslint/csslint.js
+++ b/vendor-overwrites/csslint/csslint.js
@@ -263,7 +263,8 @@ var CSSLint = (() => {
     if (!m) return;
 
     const nextLine = () => {
-      eol = (text.indexOf('\n', eol + 1) + 1 || text.length + 1) - 1;
+      eol = text.indexOf('\n', eol + 1);
+      if (eol < 0) eol = text.length;
       lineno++;
     };
 

--- a/vendor-overwrites/csslint/csslint.js
+++ b/vendor-overwrites/csslint/csslint.js
@@ -268,9 +268,10 @@ var CSSLint = (() => {
       lineno++;
     };
 
-    while (eol <= m.index) nextLine();
-
     do {
+      // account for the lines between the previous and current match
+      while (eol <= m.index) nextLine();
+
       const ovr = m[1].toLowerCase();
       const cmd = ovr.split(':', 1)[0];
       const i = cmd.length + 1;
@@ -289,15 +290,15 @@ var CSSLint = (() => {
         }
 
         case 'ignore':
-          if (ovr.lastIndexOf('start', i) > 0) {
+          if (ovr.includes('start')) {
             if (ignoreStart === null) {
-              ignoreStart = lineno;
+              ignoreStart = lineno + 1;
             }
             break;
           }
-          if (ovr.lastIndexOf('end', i) > 0) {
+          if (ovr.includes('end')) {
             ignoreEnd = lineno;
-            if (ignoreStart !== null && ignoreEnd !== null) {
+            if (ignoreStart && ignoreEnd) {
               ignore.push([ignoreStart, ignoreEnd]);
               ignoreStart = ignoreEnd = null;
             }
@@ -313,8 +314,6 @@ var CSSLint = (() => {
             ruleset[property.trim()] = mapped === undefined ? 1 : mapped;
           });
       }
-
-      nextLine();
     } while ((m = RX_EMBEDDED.exec(text)));
 
     // Close remaining ignore block, if any

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -885,12 +885,15 @@ self.parserlib = (() => {
         if (part.tokenType === Tokens.USO_VAR) return true;
         if (part.type !== 'function' || !part.expr) return false;
         const subparts = part.expr.parts;
-        return subparts.length &&
-          lower(part.name) === 'var' &&
-          subparts[0].type === 'custom-property' && (
-            subparts.length === 1 ||
-            subparts[1].text === ','
-          );
+        if (!subparts.length) return false;
+        const name = lower(part.name);
+        return (
+          name === 'var' && subparts[0].type === 'custom-property' ||
+          name === 'env' && subparts[0].type === 'identifier'
+        ) && (
+          subparts.length === 1 ||
+          subparts[1].text === ','
+        );
       },
 
       '<width>': '<length> | <percentage> | auto',
@@ -2666,7 +2669,7 @@ self.parserlib = (() => {
     known.add(value.text);
 
     function throwEndExpected(token, force) {
-      if (force || token.name !== 'var' || token.type !== 'function') {
+      if (force || (token.name !== 'var' && token.name !== 'env') || token.type !== 'function') {
         throw new ValidationError(`Expected end of value but found '${token.text}'.`, token);
       }
     }

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -467,6 +467,7 @@ self.parserlib = (() => {
     'marquee-speed':      1,
     'marquee-style':      1,
     'mask':               1,
+    'mask-image':         '[ none | <image> | <uri> ]#',
     'max-height':         'none | <width-height>',
     'max-width':          'none | <width-height>',
     'min-height':         'auto | <width-height>',

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -498,7 +498,9 @@ self.parserlib = (() => {
     'outline-offset':  '<length>',
     'outline-style':   '<border-style> | auto',
     'outline-width':   '<border-width>',
-    'overflow':        '<overflow>',
+    'overflow':        '<overflow>{1,2}',
+    'overflow-block':  '<overflow>',
+    'overflow-inline': '<overflow>',
     'overflow-style':  1,
     'overflow-wrap':   'normal | break-word',
     'overflow-x':      '<overflow>',
@@ -835,7 +837,7 @@ self.parserlib = (() => {
         return this['<number>'](part) && part.value >= 0 && part.value <= 1;
       },
 
-      '<overflow>': 'visible | hidden | scroll | auto',
+      '<overflow>': 'visible | hidden | clip | scroll | auto',
 
       '<overflow-position>': 'unsafe | safe',
 

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -603,15 +603,18 @@ self.parserlib = (() => {
     'text-decoration-skip':  'none | [ objects || [ spaces | [ leading-spaces || trailing-spaces ] ] || ' +
                              'edges || box-decoration ]',
     'text-decoration-style': '<text-decoration-style>',
-    'text-emphasis':    1,
+    'text-emphasis':         '<text-emphasis-style> || <color>',
+    'text-emphasis-style':   '<text-emphasis-style>',
+    'text-emphasis-position': '[ over | under ] && [ right | left ]?',
     'text-height':      1,
     'text-indent':      '<length> | <percentage>',
     'text-justify':     'auto | none | inter-word | inter-ideograph | inter-cluster | distribute | kashida',
     'text-outline':     1,
     'text-overflow':    'clip | ellipsis',
     'text-rendering':   'auto | optimizeSpeed | optimizeLegibility | geometricPrecision',
-    'text-shadow':      'none | [ [ <color> && <length>{2,3} ] | <length>{2,3} ]#',
+    'text-shadow':      'none | [ <color>? && <length>{2,3} ]#',
     'text-transform':   'capitalize | uppercase | lowercase | none',
+    'text-underline-position': 'auto | [ under || [ left | right ] ]',
     'text-wrap':        'normal | none | avoid',
     'top':              '<width>',
     'touch-action':     'auto | none | pan-x | pan-y | pan-left | pan-right | pan-up | pan-down | manipulation',
@@ -1058,6 +1061,10 @@ self.parserlib = (() => {
       '<single-timing-function>': 'linear | <cubic-bezier-timing-function> | <step-timing-function> | frames()',
 
       '<text-decoration-line>': 'none | [ underline || overline || line-through || blink ]',
+
+      '<text-emphasis-style>': 'none | ' +
+                               '[ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | ' +
+                               '<string>',
 
       '<track-list>': '[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?',
 

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -690,7 +690,7 @@ self.parserlib = (() => {
 
       '<basic-shape>': 'inset() | circle() | ellipse() | polygon()',
 
-      '<bg-image>': '<image> | <gradient> | none',
+      '<bg-image>': '<image> | none',
 
       '<blend-mode>': 'normal | multiply | screen | overlay | darken | lighten | color-dodge | ' +
                       'color-burn | hard-light | soft-light | difference | exclusion | hue | ' +
@@ -774,7 +774,7 @@ self.parserlib = (() => {
         return this['<ident>'](part) && !this['<generic-family>'](part);
       },
 
-      '<image>': '<uri>',
+      '<image>': '<uri> | <gradient> | cross-fade()',
 
       '<inflexible-breadth>': '<length-percentage> | min-content | max-content | auto',
 

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -553,7 +553,7 @@ self.parserlib = (() => {
     'rest-before':      1,
     'richness':         1,
     'right':            '<width>',
-    'rotate':           'none | <number>{3}? <angle>',
+    'rotate':           'none | [ <number>{3} ]? <angle>',
     'rotation':         1,
     'rotation-point':   1,
     'row-gap':          '<row-gap>',

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -194,6 +194,7 @@ self.parserlib = (() => {
     'border-bottom-right-radius': '<x-one-radius>',
     'border-bottom-style':        '<border-style>',
     'border-bottom-width':        '<border-width>',
+    'border-boundary':            'none | parent | display',
     'border-inline-color':        '<color>{1,2}',
     'border-inline-end':          '<border-shorthand>',
     'border-inline-end-color':    '<color>',
@@ -561,6 +562,7 @@ self.parserlib = (() => {
 
     // S
     'scale':             'none | <number>{1,3}',
+    'shape-inside':      'auto | outside-shape | [ <basic-shape> || shape-box ] | <image> | display',
     'shape-rendering':   'auto | optimizeSpeed | crispEdges | geometricPrecision',
     'size':              1,
     'speak':             'normal | none | spell-out',
@@ -4240,14 +4242,25 @@ self.parserlib = (() => {
 
     _viewport() {
       const stream = this._tokenStream;
-      stream.mustMatch(Tokens.VIEWPORT_SYM);
+      const start = stream.mustMatch(Tokens.VIEWPORT_SYM);
 
-      this.fire('startviewport');
+      // only viewport-fit is allowed but we're reusing MediaQuery syntax unit,
+      // and accept anything for the sake of simplicity since the spec isn't yet final:
+      // https://drafts.csswg.org/css-round-display/#extending-viewport-rule
+      const descriptors = this._mediaQueryList();
+
+      this.fire({
+        type: 'startviewport',
+        descriptors,
+      }, start);
 
       this._ws();
       this._readDeclarations();
 
-      this.fire('endviewport');
+      this.fire({
+        type: 'endviewport',
+        descriptors,
+      });
     }
 
     _document() {
@@ -5381,6 +5394,7 @@ self.parserlib = (() => {
       [Tokens.MEDIA_SYM, Parser.prototype._media],
       [Tokens.SUPPORTS_SYM, Parser.prototype._supports],
       [Tokens.DOCUMENT_SYM, Parser.prototype._documentMisplaced],
+      [Tokens.VIEWPORT_SYM, Parser.prototype._viewport],
     ]),
 
     media: new Map([

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -553,7 +553,7 @@ self.parserlib = (() => {
     'rest-before':      1,
     'richness':         1,
     'right':            '<width>',
-    'rotate':           'none | [ <number>{3} ]? <angle>',
+    'rotate':           'none | [ x | y | z | <number>{3} ]? && <angle>',
     'rotation':         1,
     'rotation-point':   1,
     'row-gap':          '<row-gap>',


### PR DESCRIPTION
I didn't test the performance impact of adding `env()` so hopefully someone tests it here.

* fixed embedded overrides broken long time ago:

  ```js
  /* csslint ignore:start */
      "the chunk of code where errors won't be reported"
      "the chunk's start is hardwired to the of the opening comment"
      "the chunk's end is hardwired to the line of the closing comment"
  /* csslint ignore:end */
  ```
  ```js
  /* csslint allow:rulename1,rulename2,... */
      "allows to break the specified rules on a single line of code that follows the comment"
  ```  
  ```js
  /* csslint rulename1 */
  /* csslint rulename2:N */
  /* csslint rulename3:N, rulename4:N */
    "entire code is affected;"
    "comments futher down the code extend/override previous comments of this kind"
  ```

  `N` can be one of the following:

  * `2` or `true` means "error"
  * `1` or nothing means "warning" - note in the latter case `:` can also be omitted
  * `0` or `false` means "ignore"

---

* Notable additions: `env()`, `mask-image` (in Chrome it's -webkit- prefixed), `:is` (the future :any)
* Notable fixes:
  * `&&` in grammarParser which fixed `text-shadow` and some rare values in `display`
  * `rotate`
