### PR TITLE
fix: alignment in li.applies-to-everything

### DIFF
--- a/edit/edit.css
+++ b/edit/edit.css
@@ -820,7 +820,8 @@ html:not(.usercss) .usercss-only,
 }
 
 .CodeMirror-linewidget li.applies-to-everything {
-  margin-top: 0.2rem;
+  margin-top: 0;
+  margin-left: 5px;
 }
 
 /************ reponsive layouts ************/


### PR DESCRIPTION
When typing `@-moz-document` in stylus the applies to <Everything> word is misaligned

![alignment](https://user-images.githubusercontent.com/31389848/51311370-0cba9500-1a49-11e9-86ac-4eccbee3dcea.gif)

This seems to fix it.

![align](https://user-images.githubusercontent.com/31389848/51311549-78046700-1a49-11e9-83a1-468911f191c3.PNG)

