### PR TITLE
Add: enable usercss updateURL

### DIFF
--- a/install-usercss/install-usercss.js
+++ b/install-usercss/install-usercss.js
@@ -307,9 +307,9 @@
 
     // set updateUrl
     const checker = $('.set-update-url input[type=checkbox]');
-    // prefer the installation URL unless drag'n'dropped on the manage page
+    // only use the installation URL if not specified in usercss
     const installationUrl = (params.get('updateUrl') || '').replace(/^blob.+/, '');
-    const updateUrl = new URL(installationUrl || style.updateUrl || DUMMY_URL);
+    const updateUrl = new URL(style.updateUrl || installationUrl || DUMMY_URL);
     if (dup && dup.updateUrl === updateUrl.href) {
       checker.checked = true;
       // there is no way to "unset" updateUrl, you can only overwrite it.

--- a/install-usercss/install-usercss.js
+++ b/install-usercss/install-usercss.js
@@ -335,7 +335,7 @@
 
     // live reload
     const setLiveReload = $('.live-reload input[type=checkbox]');
-    if (updateUrl.protocol !== 'file:') {
+    if (!installationUrl || !installationUrl.startsWith('file:')) {
       setLiveReload.parentNode.remove();
     } else {
       setLiveReload.addEventListener('change', () => {

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -7,7 +7,7 @@ const usercss = (() => {
     author: undefined,
     description: undefined,
     homepageURL: 'url',
-    // updateURL: 'updateUrl',
+    updateURL: 'updateUrl',
     name: undefined,
   };
   const RX_META = /\/\*!?\s*==userstyle==[\s\S]*?==\/userstyle==\s*\*\//i;


### PR DESCRIPTION
Fixes #650.

This PR allows usercss to set `@updateURL` for all cases, even if the style is installed from an available source. For example, if you install Github Dark from `https://raw.githubusercontent.com/StylishThemes/GitHub-Dark/master/github-dark.user.css`, the update URL becomes `https://stylishthemes.github.io/GitHub-Dark/github-dark.user.css` in this PR.

Style hoster can also use this method to trigger a redirect, which doesn't require users to re-install the style to overwrite the updateURL.

If `@updateURL` is not defined in usercss, installation URL is used like before.