### PR TITLE
Improve exclude rule matching - Fixes #678

### DIFF
--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -523,7 +523,7 @@ const styleManager = (() => {
   }
 
   function buildGlob(text) {
-    return '^' + escapeRegExp(text).replace(/\\\\\\\*|\\\*/g, m => m.length > 2 ? m : '.*') + '$';
+    return '^' + escapeRegExp(text).replace(/\\\\\\\*|\\\*/g, m => m.length > 2 ? m : '((\/|#|\\?).*)?') + '$';
   }
 
   function getDomain(url) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -359,9 +359,9 @@ function styleExcluded({exclusions}, type) {
 
 function getExcludeRule(type) {
   if (type === 'domain') {
-    return new URL(tabURL).origin + '/*';
+    return new URL(tabURL).origin + '*';
   }
-  return tabURL + '*';
+  return tabURL.split(/#|\?/)[0].replace(/\/$/, '') + '*';
 }
 
 Object.assign(handleEvent, {


### PR DESCRIPTION
Alright, I took my best shot at this in the interest of expediting this feature's long awaited debut. I think it accounts for all the problematic example URLs. If it's ugly, feel free to improve it, but I think the method is decent. If it's not perfect, hopefully it's at least going in a useful direction.

Strip params and any possible trailing forward slashes in rules and then tweak the match regex to allow only the strict base URL-prefix (with any possible params), or the base prefix with any succeeding path, provided it follows a forward slash.

The "Exclude the current URL" menu item and checkbox only work on the root prefix URL you make the rule on. This seems like a separate bug which was already present in the previous version. I didn't have any luck fixing it. @eight04 ?