### PR TITLE
Dropbox workaround for Firefox on Android (#657)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -110,6 +110,9 @@
       "js": ["content/install-hook-usercss.js"]
     }
   ],
+  "web_accessible_resources": [
+    "/sync/dropbox-oauth.html"
+  ],
   "browser_action": {
     "default_icon": {
       "16": "/images/icon/16w.png",

--- a/sync/dropbox-auth-receiver.js
+++ b/sync/dropbox-auth-receiver.js
@@ -1,0 +1,11 @@
+/* global chromeLocal */
+'use strict';
+
+window.onload = () => {
+  const params = new URLSearchParams(new URL(location.href).hash.substr(1));
+  /* it uses browser direct here because it supports just firefox yet */
+  chromeLocal.setValue('dropbox_access_token', params.get('access_token'))
+  .then(() => {
+    window.location.href = window.location.origin + '/manage.html';
+  });
+}

--- a/sync/dropbox-oauth.html
+++ b/sync/dropbox-oauth.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OAuth Receiver</title>
+  <script async defer src="../js/storage-util.js"></script>
+  <script async defer src="./dropbox-auth-receiver.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/sync/import-export-dropbox.js
+++ b/sync/import-export-dropbox.js
@@ -3,7 +3,8 @@
   $ $create t chromeLocal API getOwnTab */
 'use strict';
 
-const DROPBOX_API_KEY = 'zg52vphuapvpng9';
+// const DROPBOX_API_KEY = 'zg52vphuapvpng9';
+const DROPBOX_API_KEY = 'uyfixgzre8v1bkg';
 const FILENAME_ZIP_FILE = 'stylus.json';
 const DROPBOX_FILE = 'stylus.zip';
 const API_ERROR_STATUS_FILE_NOT_FOUND = 409;
@@ -35,6 +36,11 @@ function requestDropboxAccessToken() {
     clientId: DROPBOX_API_KEY,
     fetch
   });
+  const isFirefoxAndroid = /Android/.test(navigator.userAgent) && /Mozilla/.test(navigator.userAgent);
+  if (isFirefoxAndroid) {
+    window.location.href = client.getAuthenticationUrl(window.location.origin + '/sync/dropbox-oauth.html');
+    return;
+  }
   const authUrl = client.getAuthenticationUrl(getRedirectUrlAuthFlow());
   return launchWebAuthFlow({url: authUrl, interactive: true})
   .then(urlReturned => {
@@ -51,9 +57,9 @@ function uploadFileDropbox(client, stylesText) {
 $('#sync-dropbox-export').onclick = () => {
   const mode = localStorage.installType;
   const title = t('syncDropboxStyles');
-  const text = mode === 'normal' ? t('connectingDropbox') : t('connectingDropboxNotAllowed');
-  messageProgressBar({title, text});
-  if (mode !== 'normal') return;
+  // const text = mode === 'normal' ? t('connectingDropbox') : t('connectingDropboxNotAllowed');
+  // messageProgressBar({title, text});
+  // if (mode !== 'normal') return;
 
   hasDropboxAccessToken()
   .then(token => token || requestDropboxAccessToken())
@@ -125,9 +131,9 @@ $('#sync-dropbox-export').onclick = () => {
 $('#sync-dropbox-import').onclick = () => {
   const mode = localStorage.installType;
   const title = t('retrieveDropboxSync');
-  const text = mode === 'normal' ? t('connectingDropbox') : t('connectingDropboxNotAllowed');
-  messageProgressBar({title, text});
-  if (mode !== 'normal') return;
+  // const text = mode === 'normal' ? t('connectingDropbox') : t('connectingDropboxNotAllowed');
+  // messageProgressBar({title, text});
+  // if (mode !== 'normal') return;
 
   hasDropboxAccessToken()
   .then(token => token || requestDropboxAccessToken())


### PR DESCRIPTION
Hello guys, this is the workaround that I found to make dropbox works on Firefox Android, related to #657. 
Basically, I'm using an internal HTML file to intercept the access_token from dropbox redirect and save it in the localStorage to use it after. For doing that, I had to add the `web_accessible_resources` key on manifest.json (@tophf told me to not use that in the PR #393, but I couldn't find another way). It's enabled only for firefox on android.

This is the XPI to test on device: [stylus-1.5.2.zip](https://github.com/openstyles/stylus/files/2975947/stylus-1.5.2.zip) - It's using my key from dropbox and to test it just pass me the URL temporary from the addon (you can find it in the dropbox error page)
In this link you can find more about how to test it: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android

If you find anything weird or something that can be improved, just let me know, please.

EDIT: 
ps: before merging it, I have to remove the comments from the test mode, which validates if it's a normal mode or a dev mode.