### PR TITLE
Improve height restriction for popup config dialog

### DIFF
--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -433,8 +433,8 @@ function configDialog(style) {
     const MIN_HEIGHT = 250 + PADDING;
     colorpicker.remove();
 
-    width = constrain(MIN_WIDTH, 800, width + PADDING);
-    height = constrain(MIN_HEIGHT, 600, height + PADDING);
+    width = constrain(MIN_WIDTH, 798, width + PADDING);
+    height = constrain(MIN_HEIGHT, 598, height + PADDING);
     document.body.style.setProperty('min-width', width + 'px', 'important');
     document.body.style.setProperty('min-height', height + 'px', 'important');
   }

--- a/msgbox/msgbox.css
+++ b/msgbox/msgbox.css
@@ -150,6 +150,7 @@
   justify-content: center;
 }
 #message-box.stylus-popup > div {
+  max-height: 570px;
   max-width: 90vw;
   top: auto;
   right: auto;


### PR DESCRIPTION
Noticed unnecessary overflow in Github Dark's config dialog. We should allow it to utilize available height.