### PR TITLE
Add: auto resize editors on init in section editor

### DIFF
--- a/edit/edit.css
+++ b/edit/edit.css
@@ -311,6 +311,7 @@ input:invalid {
 }
 .section .CodeMirror {
   margin-bottom: .875rem;
+  box-sizing: border-box;
 }
 /* deleted section */
 .deleted-section {

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -263,13 +263,19 @@ input:invalid {
 #lint:not([open]) + #footer {
   margin-top: 4em;
 }
-/************ content ***********/
-#sections > * {
+/************ section editor ***********/
+.section-editor .section {
   margin: 0 0.7rem;
   padding: 1rem;
 }
-#sections > :not(:first-child) {
+.section-editor .section:not(:first-child) {
   border-top: 2px solid hsl(0, 0%, 80%);
+}
+.section-editor:not(.section-editor-ready) .section {
+  visibility: hidden;
+}
+.section-editor:not(.section-editor-ready) .CodeMirror {
+  height: 0;
 }
 .add-section:after {
   content: attr(short-text);
@@ -951,12 +957,8 @@ html:not(.usercss) .usercss-only,
     flex: 1;
   }
   #sections > * {
-    margin: 0 .5rem .5rem;
-    padding: .5rem 0 0;
-  }
-  #sections > *:first-child {
-    margin: .5rem;
-    padding: 0;
+    margin: 0 .5rem;
+    padding: .5rem 0;
   }
   .usercss .CodeMirror-scroll {
     max-height: calc(100vh - var(--header-narrow-min-height));

--- a/edit/refresh-on-view.js
+++ b/edit/refresh-on-view.js
@@ -10,6 +10,7 @@ CodeMirror.defineExtension('refreshOnView', function () {
   const cm = this;
   if (typeof IntersectionObserver === 'undefined') {
     // uh
+    cm.isRefreshed = true;
     cm.refresh();
     return;
   }
@@ -18,6 +19,7 @@ CodeMirror.defineExtension('refreshOnView', function () {
     for (const entry of entries) {
       if (entry.isIntersecting) {
         // wrapper.style.visibility = 'visible';
+        cm.isRefreshed = true;
         cm.refresh();
         observer.disconnect();
       }

--- a/edit/sections-editor-section.js
+++ b/edit/sections-editor-section.js
@@ -9,7 +9,11 @@ function createResizeGrip(cm) {
   const resizeGrip = template.resizeGrip.cloneNode(true);
   wrapper.appendChild(resizeGrip);
   let lastClickTime = 0;
+  let initHeight;
+  let initY;
   resizeGrip.onmousedown = event => {
+    initHeight = wrapper.offsetHeight;
+    initY = event.pageY;
     if (event.button !== 0) {
       return;
     }
@@ -31,9 +35,8 @@ function createResizeGrip(cm) {
     document.addEventListener('mouseup', resizeStop);
 
     function resize(e) {
-      const cmPageY = wrapper.getBoundingClientRect().top + window.scrollY;
-      const height = Math.max(minHeight, e.pageY - cmPageY);
-      if (height !== wrapper.clientHeight) {
+      const height = Math.max(minHeight, initHeight + e.pageY - initY);
+      if (height !== wrapper.offsetHeight) {
         cm.setSize(null, height);
       }
     }

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -13,6 +13,8 @@ function createSectionsEditor({style, onTitleChanged}) {
   const container = $('#sections');
   const sections = [];
 
+  container.classList.add('section-editor');
+
   const nameEl = $('#name');
   nameEl.addEventListener('input', () => {
     dirty.modify('name', style.name, nameEl.value);
@@ -99,11 +101,16 @@ function createSectionsEditor({style, onTitleChanged}) {
       if (sections.every(s => s.cm.isRefreshed)) {
         fitToAvailableSpace();
       }
+      setTimeout(() => {
+        container.classList.add('section-editor-ready');
+      }, 50);
     }
   }
 
   function fitToAvailableSpace() {
-    const available = window.innerHeight - container.offsetHeight;
+    const available =
+      Math.floor(container.offsetHeight - sections.reduce((h, s) => h + s.el.offsetHeight, 0)) ||
+      window.innerHeight - container.offsetHeight;
     if (available <= 0) {
       return;
     }

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -107,10 +107,10 @@ function createSectionsEditor({style, onTitleChanged}) {
     if (available <= 0) {
       return;
     }
-    for (const section of sections) {
-      const cmHeight = section.cm.getWrapperElement().offsetHeight;
-      section.cm.setSize(null, cmHeight + Math.floor(available / sections.length));
-    }
+    const cmHeights = sections.map(s => s.cm.getWrapperElement().offsetHeight);
+    sections.forEach((section, i) => {
+      section.cm.setSize(null, cmHeights[i] + Math.floor(available / sections.length));
+    });
   }
 
   function genId() {


### PR DESCRIPTION
Fixes #722.

1. Try to fit each editor to its content.
2. If the section is larger than the window, shrink the editor so the section can fit the window.
3. After every editor is loaded and there is an available space, stretch each editor with `availableSpace / sections.length`.