### PR TITLE
Add a backup message reminder

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -92,6 +92,10 @@
     "message": "Select a file or drag and drop to this page.",
     "description": "Message for backup"
   },
+  "backupReminderMessage": {
+    "message": "It's about that time to backup (export) your styles!",
+    "description": "Tooltip shown to remind users to backup their styles"
+  },
   "bckpInstStyles": {
     "message": "Export styles"
   },

--- a/manage.html
+++ b/manage.html
@@ -373,6 +373,7 @@
       <details id="backup" data-pref="manage.backup.expanded">
         <summary><h2 id="backup-title" i18n-text="backupButtons"></h2></summary>
         <span id="backup-message" i18n-text="backupMessage"></span>
+        <span id="backup-reminder-tooltip" i18n-text="backupReminderMessage"></span>
         <div id="backup-buttons">
           <div class="dropdown">
             <button class="dropbtn">

--- a/manage.html
+++ b/manage.html
@@ -376,10 +376,9 @@
         <div id="backup-buttons">
           <div class="dropdown">
             <button class="dropbtn">
-              <span>Export</span>
+              <span i18n-text="exportLabel"></span>
               <svg class="svg-icon select-arrow"><use xlink:href="#svg-icon-select-arrow"/></svg>
             </button>
-
             <div class="dropdown-content">
               <a href="#" id="file-all-styles" i18n-text="bckpInstStyles"></a>
               <a href="#" id="sync-dropbox-export" i18n-text="syncDropboxStyles"></a>
@@ -388,7 +387,7 @@
 
           <div class="dropdown">
             <button class="dropbtn">
-              <span>Import</span>
+              <span i18n-text="importLabel"></span>
               <svg class="svg-icon select-arrow"><use xlink:href="#svg-icon-select-arrow"/></svg>
             </button>
 

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -1046,6 +1046,15 @@ input[id^="manage.newUI"] {
   text-overflow: ellipsis;
 }
 
+#backup.show-reminder[open] summary {
+  padding-bottom: 0;
+}
+
+#backup.show-reminder #backup-message,
+#backup:not(.show-reminder) #backup-reminder-tooltip {
+  display: none;
+}
+
 /* export/import buttons */
 #backup-buttons .dropbtn {
   padding: 3px 7px;
@@ -1070,6 +1079,14 @@ input[id^="manage.newUI"] {
   min-width: 160px;
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   z-index: 1;
+}
+
+#backup-reminder-tooltip {
+  display: block;
+  padding: 10px;
+  background: #cb4;
+  color: #000;
+  cursor: pointer;
 }
 
 #backup-buttons .dropdown-content a {


### PR DESCRIPTION
This message box will appear every 14 days - does this setting sound appropriate? Or, should we make it modifiable by the user?

![backup](https://user-images.githubusercontent.com/136959/59894721-47817a00-93a7-11e9-8a50-fd6f5b5b6864.gif)

* Click to close, but it will reappear the next time you open the manager.
* Export styles to reset the timer.
* Importing new styles will *not* reset the timer.
* Will open collapsed backup block, but will restore that state once closed.

I don't think it's too naggy, but it's bright enough to draw attention.