### PR TITLE
Fix colorpicker

### DIFF
--- a/vendor-overwrites/colorpicker/colorconverter.js
+++ b/vendor-overwrites/colorpicker/colorconverter.js
@@ -54,12 +54,14 @@ const colorConverter = (() => {
   }
 
   function validatePercentage(s) {
-    const match = s.match(/^(\d+|\d*\.\d+)%$/);
-    return match && Number(match[1]) >= 0 && Number(match[1]) <= 100;
+    if (!s.endsWith('%')) return false;
+    const n = Number(s.slice(0, -1));
+    return n >= 0 && n <= 100;
   }
 
   function validateNum(s) {
-    return /^\d+$/.test(s) && Number(s) >= 0 && Number(s) <= 255;
+    const n = Number(s);
+    return n >= 0 && n <= 255;
   }
 
   function validateHSL(nums) {
@@ -74,7 +76,8 @@ const colorConverter = (() => {
     if (alpha.endsWith('%')) {
       return validatePercentage(alpha);
     }
-    return Number(alpha) >= 0 && Number(alpha) <= 1;
+    const n = Number(alpha);
+    return n >= 0 && n <= 1;
   }
 
   function parse(str) {

--- a/vendor-overwrites/colorpicker/colorview.js
+++ b/vendor-overwrites/colorpicker/colorview.js
@@ -363,7 +363,12 @@
 
     for (let i = styleIndex; i + 1 < styles.length; i += 2) {
       style = styles[i + 1];
-      const styleSupported = style && (style.includes('atom') || style.includes('keyword'));
+      const styleSupported = style && (
+        // old CodeMirror
+        style.includes('atom') || style.includes('keyword') ||
+        // new CodeMirror since 5.48
+        style.includes('variable callee')
+      );
       if (!styleSupported) continue;
 
       start = i > 2 ? styles[i - 2] : 0;
@@ -574,7 +579,7 @@
 
 
   function findNearestColor({styles, text}, pos) {
-    const ALLOWED_STYLES = ['atom', 'keyword', 'comment', 'string'];
+    const ALLOWED_STYLES = ['atom', 'keyword', 'callee', 'comment', 'string'];
     let start, color, prevStart, prevColor, m;
     RX_DETECT.lastIndex = Math.max(0, pos - 1000);
 


### PR DESCRIPTION
fixes #744 and restores scientific number notation support in colors like `rgba(1.5E2 0 0 / .5e2%)` broken in 7ea0200