### PR TITLE
min-width for action buttons in popup

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -172,6 +172,10 @@ body.blocked > DIV {
   text-decoration: none;
 }
 
+#installed .actions > a {
+  min-width: 22px;
+}
+
 /* entry */
 .entry {
   position: relative;


### PR DESCRIPTION
they had different sizes and especially the slim stacked dots (open menu) were unfriendly to click