### PR TITLE
Popup border

### DIFF
--- a/options.html
+++ b/options.html
@@ -109,7 +109,7 @@
             <span></span>
           </span>
         </label>
-        <label class="chromium-only">
+        <label class="chromium-only chrome-no-popup-border">
           <span i18n-text="popupBorders" i18n-title="popupBordersTooltip"></span>
           <span class="onoffswitch">
             <input type="checkbox" id="popup.borders" class="slider">

--- a/options/options.css
+++ b/options/options.css
@@ -17,6 +17,7 @@ body {
   min-width: 480px;
   max-width: 800px;
   width: max-content;
+  overflow-x: hidden;
 }
 
 @supports (-moz-appearance:none) {

--- a/options/options.css
+++ b/options/options.css
@@ -33,7 +33,8 @@ body {
   }
 }
 
-.firefox .chromium-only {
+.firefox .chromium-only,
+.chromium-only.chrome-no-popup-border {
   display: none;
 }
 

--- a/options/options.js
+++ b/options/options.js
@@ -8,6 +8,13 @@ setupRadioButtons();
 enforceInputRange($('#popupWidth'));
 setTimeout(splitLongTooltips);
 
+if (CHROME >= 3167 && CHROME <= 3704) {
+  const borderOption = $('.chrome-no-popup-border');
+  if (borderOption) {
+    borderOption.classList.remove('chrome-no-popup-border');
+  }
+}
+
 // collapse #advanced block in Chrome pre-66 (classic chrome://extensions UI)
 if (!FIREFOX && !OPERA && CHROME < 3343) {
   const block = $('#advanced');

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -42,7 +42,10 @@ prefs.subscribe(['popup.stylesFirst'], (key, stylesFirst) => {
   document.body.insertBefore(installed, before);
 });
 prefs.subscribe(['popupWidth'], (key, value) => setPopupWidth(value));
-prefs.subscribe(['popup.borders'], (key, value) => toggleSideBorders(value));
+
+if (CHROME >= 3167 && CHROME <= 3704) {
+  prefs.subscribe(['popup.borders'], (key, value) => toggleSideBorders(value));
+}
 
 function onRuntimeMessage(msg) {
   switch (msg.method) {
@@ -68,7 +71,7 @@ function setPopupWidth(width = prefs.get('popupWidth')) {
 function toggleSideBorders(state = prefs.get('popup.borders')) {
   // runs before <body> is parsed
   const style = document.documentElement.style;
-  if (CHROME >= 3167 && state) {
+  if (CHROME >= 3167 && CHROME <= 3704 && state) {
     style.cssText +=
       'border-left: 2px solid white !important;' +
       'border-right: 2px solid white !important;';


### PR DESCRIPTION
Hide popup border option in newer versions of Chrome.

See [tophf's suggested fix here](https://github.com/openstyles/stylus/issues/226#issuecomment-463515491).