### PR TITLE
find @-moz-doc sections faster in the editor

### DIFF
--- a/edit/applies-to-line-widget.js
+++ b/edit/applies-to-line-widget.js
@@ -494,7 +494,7 @@ function createAppliesToLineWidget(cm) {
     const eatToken = sticky => {
       if (!sticky) skipSpace(pos, posEnd);
       pos.ch++;
-      const token = cm.getTokenAt(pos);
+      const token = cm.getTokenAt(pos, true);
       pos.ch = token.end;
       return CodeMirror.cmpPos(pos, posEnd) <= 0 ? token : {};
     };

--- a/edit/applies-to-line-widget.js
+++ b/edit/applies-to-line-widget.js
@@ -543,6 +543,11 @@ function createAppliesToLineWidget(cm) {
           ch++;
           lookForEnd = false;
         }
+        // EOL is a whitespace so we'll check the next line
+        if (ch >= text.length) {
+          ch = 0;
+          return;
+        }
         RX_SPACE.lastIndex = ch;
         const m = RX_SPACE.exec(text);
         if (!m) {

--- a/edit/applies-to-line-widget.js
+++ b/edit/applies-to-line-widget.js
@@ -501,7 +501,7 @@ function createAppliesToLineWidget(cm) {
     const docCur = cm.getSearchCursor('@-moz-document', posStart);
     while (docCur.findNext() &&
            CodeMirror.cmpPos(docCur.pos.to, posEnd) <= 0) {
-      if (!/\bdef\b/.test(cm.getTokenTypeAt(docCur.pos.from))) continue;
+      if (/\b(string|comment)\b/.test(cm.getTokenTypeAt(docCur.pos.from))) continue;
       const applies = [];
       pos = docCur.pos.to;
       do {

--- a/edit/applies-to-line-widget.js
+++ b/edit/applies-to-line-widget.js
@@ -5,7 +5,7 @@
 
 function createAppliesToLineWidget(cm) {
   const THROTTLE_DELAY = 400;
-  const RX_SPACE = /(?:\s+|\s*\/\*)+/y;
+  const RX_SPACE = /(?:\s+|\/\*)+/y;
   let TPL, EVENTS, CLICK_ROUTE;
   let widgets = [];
   let fromLine, toLine, actualStyle;

--- a/edit/applies-to-line-widget.js
+++ b/edit/applies-to-line-widget.js
@@ -501,7 +501,9 @@ function createAppliesToLineWidget(cm) {
     const docCur = cm.getSearchCursor('@-moz-document', posStart);
     while (docCur.findNext() &&
            CodeMirror.cmpPos(docCur.pos.to, posEnd) <= 0) {
-      if (/\b(string|comment)\b/.test(cm.getTokenTypeAt(docCur.pos.from))) continue;
+      // CM can be nitpicky at token boundary so we'll check the next character
+      const safePos = {line: docCur.pos.from.line, ch: docCur.pos.from.ch + 1};
+      if (/\b(string|comment)\b/.test(cm.getTokenTypeAt(safePos))) continue;
       const applies = [];
       pos = docCur.pos.to;
       do {

--- a/edit/applies-to-line-widget.js
+++ b/edit/applies-to-line-widget.js
@@ -318,6 +318,11 @@ function createAppliesToLineWidget(cm) {
         clearWidget(removed[i]);
         removedWidget = removed[++i];
       }
+      if (removedWidget && deepEqual(removedWidget.node.__applies, section.applies, ['mark'])) {
+        yield removedWidget;
+        i++;
+        continue;
+      }
       for (const a of section.applies) {
         setupApplyMarkers(a, lineIndexes);
       }
@@ -562,6 +567,30 @@ function createAppliesToLineWidget(cm) {
   function unescapeDoubleslash(s) {
     const hasSingleEscapes = /([^\\]|^)\\([^\\]|$)/.test(s);
     return hasSingleEscapes ? s : s.replace(/\\\\/g, '\\');
+  }
+
+  function deepEqual(a, b, ignoredKeys) {
+    if (!a || !b) return a === b;
+    const type = typeof a;
+    if (type !== typeof b) return false;
+    if (type !== 'object') return a === b;
+    if (Array.isArray(a)) {
+      return Array.isArray(b) &&
+             a.length === b.length &&
+             a.every((v, i) => deepEqual(v, b[i], ignoredKeys));
+    }
+    for (const key in a) {
+      if (!Object.hasOwnProperty.call(a, key) ||
+          ignoredKeys && ignoredKeys.includes(key)) continue;
+      if (!Object.hasOwnProperty.call(b, key)) return false;
+      if (!deepEqual(a[key], b[key], ignoredKeys)) return false;
+    }
+    for (const key in b) {
+      if (!Object.hasOwnProperty.call(b, key) ||
+          ignoredKeys && ignoredKeys.includes(key)) continue;
+      if (!Object.hasOwnProperty.call(a, key)) return false;
+    }
+    return true;
   }
 
   function showRegExpTester(item) {

--- a/edit/applies-to-line-widget.js
+++ b/edit/applies-to-line-widget.js
@@ -1,5 +1,5 @@
 /* global regExpTester debounce messageBox CodeMirror template colorMimicry msg
-  $ $create t prefs tryCatch */
+  $ $create t prefs tryCatch deepEqual */
 /* exported createAppliesToLineWidget */
 'use strict';
 
@@ -572,30 +572,6 @@ function createAppliesToLineWidget(cm) {
   function unescapeDoubleslash(s) {
     const hasSingleEscapes = /([^\\]|^)\\([^\\]|$)/.test(s);
     return hasSingleEscapes ? s : s.replace(/\\\\/g, '\\');
-  }
-
-  function deepEqual(a, b, ignoredKeys) {
-    if (!a || !b) return a === b;
-    const type = typeof a;
-    if (type !== typeof b) return false;
-    if (type !== 'object') return a === b;
-    if (Array.isArray(a)) {
-      return Array.isArray(b) &&
-             a.length === b.length &&
-             a.every((v, i) => deepEqual(v, b[i], ignoredKeys));
-    }
-    for (const key in a) {
-      if (!Object.hasOwnProperty.call(a, key) ||
-          ignoredKeys && ignoredKeys.includes(key)) continue;
-      if (!Object.hasOwnProperty.call(b, key)) return false;
-      if (!deepEqual(a[key], b[key], ignoredKeys)) return false;
-    }
-    for (const key in b) {
-      if (!Object.hasOwnProperty.call(b, key) ||
-          ignoredKeys && ignoredKeys.includes(key)) continue;
-      if (!Object.hasOwnProperty.call(a, key)) return false;
-    }
-    return true;
   }
 
   function showRegExpTester(item) {

--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -242,6 +242,20 @@
     CodeMirror.commands[name] = (...args) => editor[name](...args);
   }
 
+  // speedup: reuse the old folding marks
+  const {setGutterMarker} = CodeMirror.prototype;
+  CodeMirror.prototype.setGutterMarker = function (line, gutterID, value) {
+    const o = this.state.foldGutter.options;
+    if (typeof o.indicatorOpen === 'string' ||
+        typeof o.indicatorFolded === 'string') {
+      const old = line.gutterMarkers && line.gutterMarkers[gutterID];
+      if (old ? value && value.className === old.className : !value) {
+        return line;
+      }
+    }
+    return setGutterMarker.apply(this, arguments);
+  };
+
   // CodeMirror convenience commands
   Object.assign(CodeMirror.commands, {
     toggleEditorFocus,

--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -243,6 +243,7 @@
   }
 
   // speedup: reuse the old folding marks
+  // TODO: remove when https://github.com/codemirror/CodeMirror/pull/6010 is shipped in /vendor
   const {setGutterMarker} = CodeMirror.prototype;
   CodeMirror.prototype.setGutterMarker = function (line, gutterID, value) {
     const o = this.state.foldGutter.options;

--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -250,7 +250,9 @@
     if (typeof o.indicatorOpen === 'string' ||
         typeof o.indicatorFolded === 'string') {
       const old = line.gutterMarkers && line.gutterMarkers[gutterID];
-      if (old ? value && value.className === old.className : !value) {
+      // old className can contain other names set by CodeMirror so we'll use classList
+      if (old && value && old.classList.contains(value.className) ||
+          !old && !value) {
         return line;
       }
     }

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -1,5 +1,5 @@
 /* exported getActiveTab onTabReady stringAsRegExp getTabRealURL openURL
-  getStyleWithNoCode tryRegExp sessionStorageHash download
+  getStyleWithNoCode tryRegExp sessionStorageHash download deepEqual
   closeCurrentTab */
 'use strict';
 
@@ -354,6 +354,31 @@ function deepCopy(obj) {
     copy[k] = !v || typeof v !== 'object' ? v : deepCopy(v);
   }
   return copy;
+}
+
+
+function deepEqual(a, b, ignoredKeys) {
+  if (!a || !b) return a === b;
+  const type = typeof a;
+  if (type !== typeof b) return false;
+  if (type !== 'object') return a === b;
+  if (Array.isArray(a)) {
+    return Array.isArray(b) &&
+           a.length === b.length &&
+           a.every((v, i) => deepEqual(v, b[i], ignoredKeys));
+  }
+  for (const key in a) {
+    if (!Object.hasOwnProperty.call(a, key) ||
+        ignoredKeys && ignoredKeys.includes(key)) continue;
+    if (!Object.hasOwnProperty.call(b, key)) return false;
+    if (!deepEqual(a[key], b[key], ignoredKeys)) return false;
+  }
+  for (const key in b) {
+    if (!Object.hasOwnProperty.call(b, key) ||
+        ignoredKeys && ignoredKeys.includes(key)) continue;
+    if (!Object.hasOwnProperty.call(a, key)) return false;
+  }
+  return true;
 }
 
 


### PR DESCRIPTION
Eliminates the unnecessary re-rendering of:
* Section "applies-to" widgets
* CodeMirror fold gutter marks

Alleviates #785, but not fully as there are other issues caused by CodeMirror and its addons, which someone will have to investigate separately (at the moment it seems like an architectural deficiency of CodeMirror).

I didn't test this PR extensively.

Devtools profiler in [Google Search Material Dark](https://github.com/Weikardzaena/WebsiteDarkThemes/blob/material-elevation/google-search-dark.user.css), typing inside a `@-moz-document` section:

* findAppliesTo before this PR - 2200 milliseconds
  
  ![image](https://user-images.githubusercontent.com/1310400/65388918-08254980-dd59-11e9-9ea4-da55373d15ab.png)

* findAppliesTo after this PR - 1.5 milliseconds