### PR TITLE
Fix error message when saving an empty usercss. Closes #795

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1161,6 +1161,10 @@
     "message": "Restore removed section",
     "description": "Label for the button to restore a removed section"
   },
+  "sectionEmpty": {
+    "message": "Not saved due to lack of usercss sections.\n\nAdd at least one @-moz-document domain(\"example.com\") {} section",
+    "description": "Error shown when the user tries to save an empty usercss style"
+  },
   "shortcuts": {
     "message": "Shortcuts",
     "description": "Go to shortcut configuration"

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -71,6 +71,9 @@ const usercss = (() => {
       .then(({sections, errors}) => {
         if (!errors.length) errors = false;
         if (!sections.length || errors && !allowErrors) {
+          if (!errors) {
+            errors = chrome.i18n.getMessage('sectionEmpty');
+          }
           throw errors;
         }
         style.sections = sections;


### PR DESCRIPTION
This PR adds the following message when attempting to save an empty usercss style

<img width="675" alt="2019-11-02 10_26_31-_ _xx" src="https://user-images.githubusercontent.com/136959/68073218-a2ff4380-fd5b-11e9-8570-60c7efefbdc3.png">

It is still possible, and always has been, to save an empty non-usercss style.