### PR TITLE
Simplify & speed up style injection

### DIFF
--- a/content/apply.js
+++ b/content/apply.js
@@ -134,17 +134,12 @@ self.INJECTED !== 1 && (() => {
   }
 
   function fetchParentDomain() {
-    if (parentDomain) {
-      return Promise.resolve();
-    }
-    return msg.send({
-      method: 'invokeAPI',
-      name: 'getTabUrlPrefix',
-      args: []
-    })
-      .then(newDomain => {
-        parentDomain = newDomain;
-      });
+    return parentDomain ?
+      Promise.resolve() :
+      API.getTabUrlPrefix()
+        .then(newDomain => {
+          parentDomain = newDomain;
+        });
   }
 
   function updateExposeIframes() {
@@ -168,14 +163,9 @@ self.INJECTED !== 1 && (() => {
     }
     if (STYLE_VIA_API) {
       API.styleViaAPI({method: 'updateCount'}).catch(msg.ignoreError);
-      return;
+    } else {
+      API.updateIconBadge(styleInjector.list.length).catch(console.error);
     }
-    // we have to send the tabId so we can't use `sendBg` that is used by `API`
-    msg.send({
-      method: 'invokeAPI',
-      name: 'updateIconBadge',
-      args: [styleInjector.list.length]
-    }).catch(console.error);
   }
 
   function orphanCheck() {

--- a/content/style-injector.js
+++ b/content/style-injector.js
@@ -8,8 +8,11 @@ self.createStyleInjector = self.INJECTED === 1 ? self.createStyleInjector : ({
   const PATCH_ID = 'transition-patch';
   // styles are out of order if any of these elements is injected between them
   const ORDERED_TAGS = new Set(['head', 'body', 'frameset', 'style', 'link']);
+  const IS_OWN_PAGE = Boolean(chrome.tabs);
   // detect Chrome 65 via a feature it added since browser version can be spoofed
   const isChromePre65 = chrome.app && typeof Worklet !== 'function';
+  const docRewriteObserver = RewriteObserver(_sort);
+  const docRootObserver = RootObserver(_sortIfNeeded);
   const list = [];
   const table = new Map();
   let isEnabled = true;
@@ -17,78 +20,74 @@ self.createStyleInjector = self.INJECTED === 1 ? self.createStyleInjector : ({
   // will store the original method refs because the page can override them
   let creationDoc, createElement, createElementNS;
   return {
-    // manipulation
-    addMany,
-    remove,
+    apply,
     clear,
     clearOrphans,
-    replaceAll,
-
-    // method
+    remove,
+    replace,
     toggle,
-    sort,
-
-    // state
-    outOfOrder,
     list,
-
-    // static util
-    createStyle
   };
 
-  /*
-  FF59+ workaround: allow the page to read our sheets, https://github.com/openstyles/stylus/issues/461
-  First we're trying the page context document where inline styles may be forbidden by CSP
-  https://bugzilla.mozilla.org/show_bug.cgi?id=1579345#c3
-  and since userAgent.navigator can be spoofed via about:config or devtools,
-  we're checking for getPreventDefault that was removed in FF59
-  */
-  function _initCreationDoc() {
-    creationDoc = !Event.prototype.getPreventDefault && document.wrappedJSObject;
-    if (creationDoc) {
-      ({createElement, createElementNS} = creationDoc);
-      const el = document.documentElement.appendChild(createStyle());
-      const isApplied = el.sheet;
-      el.remove();
-      if (isApplied) return;
-    }
-    creationDoc = document;
-    ({createElement, createElementNS} = document);
+  function apply(styleMap) {
+    const styles = _styleMapToArray(styleMap);
+    return !styles.length ?
+      Promise.resolve([]) :
+      docRootObserver.evade(() => {
+        if (!isTransitionPatched) _applyTransitionPatch(styles);
+        const els = styles.map(_apply);
+        _emitUpdate();
+        return els;
+      });
   }
 
-  function outOfOrder() {
-    if (!list.length) {
-      return false;
+  function clear() {
+    for (const style of list) {
+      style.el.remove();
     }
-    let el = list[0].el;
-    if (el.parentNode !== creationDoc.documentElement) {
-      return true;
-    }
-    let i = 0;
-    while (el) {
-      if (i < list.length && el === list[i].el) {
-        i++;
-      } else if (ORDERED_TAGS.has(el.localName)) {
-        return true;
+    list.length = 0;
+    table.clear();
+    _emitUpdate();
+  }
+
+  function clearOrphans() {
+    for (const el of document.querySelectorAll(`style[id^="${PREFIX}"].stylus`)) {
+      const id = el.id.slice(PREFIX.length);
+      if (/^\d+$/.test(id) || id === PATCH_ID) {
+        el.remove();
       }
-      el = el.nextElementSibling;
     }
-    // some styles are not injected to the document
-    return i < list.length;
   }
 
-  function addMany(styles) {
-    if (!isTransitionPatched) _applyTransitionPatch(styles);
-    const els = styles.map(_add);
-    onUpdate();
-    return els;
+  function remove(id) {
+    _remove(id);
+    _emitUpdate();
+  }
+
+  function replace(styleMap) {
+    const styles = _styleMapToArray(styleMap);
+    const added = new Set(styles.map(s => s.id));
+    const removed = [];
+    for (const style of list) {
+      if (!added.has(style.id)) {
+        removed.push(style.id);
+      }
+    }
+    styles.forEach(_apply);
+    removed.forEach(_remove);
+    _emitUpdate();
+  }
+
+  function toggle(_enabled) {
+    if (isEnabled === _enabled) return;
+    isEnabled = _enabled;
+    for (const style of list) {
+      style.el.disabled = !isEnabled;
+    }
   }
 
   function _add(style) {
-    if (table.has(style.id)) {
-      return _update(style);
-    }
-    const el = style.el = createStyle(style.id, style.code);
+    const el = style.el = _createStyle(style.id, style.code);
     table.set(style.id, style);
     const nextIndex = list.findIndex(i => compare(i, style) > 0);
     if (nextIndex < 0) {
@@ -103,14 +102,18 @@ self.createStyleInjector = self.INJECTED === 1 ? self.createStyleInjector : ({
     return el;
   }
 
-  // CSS transition bug workaround: since we insert styles asynchronously,
-  // the browsers, especially Firefox, may apply all transitions on page load
+  function _apply(style) {
+    return table.has(style.id) ? _update(style) : _add(style);
+  }
+
   function _applyTransitionPatch(styles) {
+    // CSS transition bug workaround: since we insert styles asynchronously,
+    // the browsers, especially Firefox, may apply all transitions on page load
     isTransitionPatched = document.readyState === 'complete';
     if (isTransitionPatched || !styles.some(s => s.code.includes('transition'))) {
       return;
     }
-    const el = createStyle(PATCH_ID, `
+    const el = _createStyle(PATCH_ID, `
       :root:not(#\\0):not(#\\0) * {
         transition: none !important;
       }
@@ -121,50 +124,7 @@ self.createStyleInjector = self.INJECTED === 1 ? self.createStyleInjector : ({
     requestAnimationFrame(() => setTimeout(() => el.remove()));
   }
 
-  function remove(id) {
-    _remove(id);
-    onUpdate();
-  }
-
-  function _remove(id) {
-    const style = table.get(id);
-    if (!style) return;
-    table.delete(id);
-    list.splice(list.indexOf(style), 1);
-    style.el.remove();
-  }
-
-  function _update({id, code}) {
-    const style = table.get(id);
-    if (style.code === code) return;
-    style.code = code;
-    // workaround for Chrome devtools bug fixed in v65
-    if (isChromePre65) {
-      const oldEl = style.el;
-      style.el = createStyle(id, code);
-      oldEl.parentNode.insertBefore(style.el, oldEl.nextSibling);
-      oldEl.remove();
-    } else {
-      style.el.textContent = code;
-    }
-    // https://github.com/openstyles/stylus/issues/693
-    style.el.disabled = !isEnabled;
-  }
-
-  function _supersede(domId) {
-    const el = document.getElementById(domId);
-    if (el) {
-      // remove if it looks like our style that wasn't cleaned up in orphanCheck
-      // (note, Firefox doesn't orphanize content scripts at all so orphanCheck will never run)
-      if (el.localName === 'style' && el.classList.contains('stylus')) {
-        el.remove();
-      } else {
-        el.id += ' superseded by Stylus';
-      }
-    }
-  }
-
-  function createStyle(id, code = '') {
+  function _createStyle(id, code = '') {
     if (!creationDoc) _initCreationDoc();
     let el;
     if (document.documentElement instanceof SVGSVGElement) {
@@ -179,7 +139,8 @@ self.createStyleInjector = self.INJECTED === 1 ? self.createStyleInjector : ({
     }
     if (id) {
       el.id = `${PREFIX}${id}`;
-      _supersede(el.id);
+      const oldEl = document.getElementById(el.id);
+      if (oldEl) oldEl.id += '-superseded-by-Stylus';
     }
     el.type = 'text/css';
     // SVG className is not a string, but an instance of SVGAnimatedString
@@ -188,54 +149,188 @@ self.createStyleInjector = self.INJECTED === 1 ? self.createStyleInjector : ({
     return el;
   }
 
-  function clear() {
-    for (const style of list) {
-      style.el.remove();
+  function _emitUpdate() {
+    if (!IS_OWN_PAGE && list.length) {
+      docRewriteObserver.start();
+      docRootObserver.start();
+    } else {
+      docRewriteObserver.stop();
+      docRootObserver.stop();
     }
-    list.length = 0;
-    table.clear();
     onUpdate();
   }
 
-  function clearOrphans() {
-    for (const el of document.querySelectorAll(`style[id^="${PREFIX}-"].stylus`)) {
-      const id = el.id.slice(PREFIX.length + 1);
-      if (/^\d+$/.test(id) || id === PATCH_ID) {
-        el.remove();
+  /*
+  FF59+ workaround: allow the page to read our sheets, https://github.com/openstyles/stylus/issues/461
+  First we're trying the page context document where inline styles may be forbidden by CSP
+  https://bugzilla.mozilla.org/show_bug.cgi?id=1579345#c3
+  and since userAgent.navigator can be spoofed via about:config or devtools,
+  we're checking for getPreventDefault that was removed in FF59
+  */
+  function _initCreationDoc() {
+    creationDoc = !Event.prototype.getPreventDefault && document.wrappedJSObject;
+    if (creationDoc) {
+      ({createElement, createElementNS} = creationDoc);
+      const el = document.documentElement.appendChild(_createStyle());
+      const isApplied = el.sheet;
+      el.remove();
+      if (isApplied) return;
+    }
+    creationDoc = document;
+    ({createElement, createElementNS} = document);
+  }
+
+  function _remove(id) {
+    const style = table.get(id);
+    if (!style) return;
+    table.delete(id);
+    list.splice(list.indexOf(style), 1);
+    style.el.remove();
+  }
+
+  function _sort() {
+    docRootObserver.evade(() => {
+      list.sort(compare);
+      for (const style of list) {
+        // moving an element resets its 'disabled' state
+        document.documentElement.appendChild(style.el);
+        style.el.disabled = !isEnabled;
+      }
+    });
+  }
+
+  function _sortIfNeeded() {
+    let needsSort;
+    let el = list.length && list[0].el;
+    if (!el) {
+      needsSort = false;
+    } else if (el.parentNode !== creationDoc.documentElement) {
+      needsSort = true;
+    } else {
+      let i = 0;
+      while (el) {
+        if (i < list.length && el === list[i].el) {
+          i++;
+        } else if (ORDERED_TAGS.has(el.localName)) {
+          needsSort = true;
+          break;
+        }
+        el = el.nextElementSibling;
+      }
+      // some styles are not injected to the document
+      if (i < list.length) needsSort = true;
+    }
+    if (needsSort) _sort();
+    return needsSort;
+  }
+
+  function _styleMapToArray(styleMap) {
+    return Object.values(styleMap).map(s => ({
+      id: s.id,
+      code: s.code.join(''),
+    }));
+  }
+
+  function _update({id, code}) {
+    const style = table.get(id);
+    if (style.code === code) return;
+    style.code = code;
+    // workaround for Chrome devtools bug fixed in v65
+    if (isChromePre65) {
+      const oldEl = style.el;
+      style.el = _createStyle(id, code);
+      oldEl.parentNode.insertBefore(style.el, oldEl.nextSibling);
+      oldEl.remove();
+    } else {
+      style.el.textContent = code;
+    }
+    // https://github.com/openstyles/stylus/issues/693
+    style.el.disabled = !isEnabled;
+  }
+
+  function RewriteObserver(onChange) {
+    // detect documentElement being rewritten from inside the script
+    let root;
+    let observing = false;
+    let timer;
+    const observer = new MutationObserver(_check);
+    return {start, stop};
+
+    function start() {
+      if (observing) return;
+      // detect dynamic iframes rewritten after creation by the embedder i.e. externally
+      root = document.documentElement;
+      timer = setTimeout(_check);
+      observer.observe(document, {childList: true});
+      observing = true;
+    }
+
+    function stop() {
+      if (!observing) return;
+      clearTimeout(timer);
+      observer.disconnect();
+      observing = false;
+    }
+
+    function _check() {
+      if (root !== document.documentElement) {
+        root = document.documentElement;
+        onChange();
       }
     }
   }
 
-  function toggle(_enabled) {
-    if (isEnabled === _enabled) return;
-    isEnabled = _enabled;
-    for (const style of list) {
-      style.el.disabled = !isEnabled;
-    }
-  }
+  function RootObserver(onChange) {
+    let digest = 0;
+    let lastCalledTime = NaN;
+    let observing = false;
+    const observer = new MutationObserver(() => {
+      if (digest) {
+        if (performance.now() - lastCalledTime > 1000) {
+          digest = 0;
+        } else if (digest > 5) {
+          throw new Error('The page keeps generating mutations. Skip the event.');
+        }
+      }
+      if (onChange()) {
+        digest++;
+        lastCalledTime = performance.now();
+      }
+    });
+    return {evade, start, stop};
 
-  function sort() {
-    list.sort(compare);
-    for (const style of list) {
+    function evade(fn) {
+      const restore = observing && start;
+      stop();
+      return new Promise(resolve => _run(fn, resolve, _waitForRoot))
+        .then(restore);
+    }
+
+    function start() {
+      if (observing) return;
+      observer.observe(document.documentElement, {childList: true});
+      observing = true;
+    }
+
+    function stop() {
+      if (!observing) return;
       // FIXME: do we need this?
-      // const copy = document.importNode(el, true);
-      // el.textContent += ' '; // invalidate CSSOM cache
-      document.documentElement.appendChild(style.el);
-      // moving an element resets its 'disabled' state
-      style.el.disabled = !isEnabled;
+      observer.takeRecords();
+      observer.disconnect();
+      observing = false;
     }
-  }
 
-  function replaceAll(styles) {
-    const added = new Set(styles.map(s => s.id));
-    const removed = [];
-    for (const style of list) {
-      if (!added.has(style.id)) {
-        removed.push(style.id);
+    function _run(fn, resolve, wait) {
+      if (document.documentElement) {
+        resolve(fn());
+        return true;
       }
+      if (wait) wait(fn, resolve);
     }
-    styles.forEach(_add);
-    removed.forEach(_remove);
-    onUpdate();
+
+    function _waitForRoot(...args) {
+      new MutationObserver((_, observer) => _run(...args) && observer.disconnect())
+        .observe(document, {childList: true});
+    }
   }
 };

--- a/js/msg.js
+++ b/js/msg.js
@@ -238,9 +238,15 @@ self.msg = self.INJECTED === 1 ? self.msg : (() => {
   }
 })();
 
-self.API = self.INJECTED === 1 ? self.API : new Proxy({}, {
+self.API = self.INJECTED === 1 ? self.API : new Proxy({
+  // Handlers for these methods need sender.tab.id which is set by `send` as it uses messaging,
+  // unlike `sendBg` which invokes the background page directly in our own extension tabs
+  getTabUrlPrefix: true,
+  updateIconBadge: true,
+  styleViaAPI: true,
+}, {
   get: (target, name) =>
-    (...args) => Promise.resolve(self.msg.sendBg({
+    (...args) => Promise.resolve(self.msg[target[name] ? 'send' : 'sendBg']({
       method: 'invokeAPI',
       name,
       args

--- a/js/msg.js
+++ b/js/msg.js
@@ -1,9 +1,8 @@
 /* global promisify deepCopy */
-/* exported msg API */
 // deepCopy is only used if the script is executed in extension pages.
 'use strict';
 
-const msg = (() => {
+self.msg = self.INJECTED === 1 ? self.msg : (() => {
   const runtimeSend = promisify(chrome.runtime.sendMessage.bind(chrome.runtime));
   const tabSend = chrome.tabs && promisify(chrome.tabs.sendMessage.bind(chrome.tabs));
   const tabQuery = chrome.tabs && promisify(chrome.tabs.query.bind(chrome.tabs));
@@ -239,9 +238,9 @@ const msg = (() => {
   }
 })();
 
-const API = new Proxy({}, {
+self.API = self.INJECTED === 1 ? self.API : new Proxy({}, {
   get: (target, name) =>
-    (...args) => Promise.resolve(msg.sendBg({
+    (...args) => Promise.resolve(self.msg.sendBg({
       method: 'invokeAPI',
       name,
       args

--- a/js/polyfill.js
+++ b/js/polyfill.js
@@ -1,6 +1,8 @@
 'use strict';
 
-(() => {
+// eslint-disable-next-line no-unused-expressions
+self.INJECTED !== 1 && (() => {
+
   if (!Object.entries) {
     Object.entries = obj => Object.keys(obj).map(k => [k, obj[k]]);
   }

--- a/js/polyfill.js
+++ b/js/polyfill.js
@@ -9,6 +9,11 @@ self.INJECTED !== 1 && (() => {
   if (!Object.values) {
     Object.values = obj => Object.keys(obj).map(k => obj[k]);
   }
+
+  // the above was shared by content scripts and workers,
+  // the rest is only needed for our extension pages
+  if (!self.chrome || !self.chrome.tabs) return;
+
   if (typeof document === 'object') {
     const ELEMENT_METH = {
       append: {

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -1,8 +1,7 @@
 /* global promisify */
-/* exported prefs */
 'use strict';
 
-const prefs = (() => {
+self.prefs = self.INJECTED === 1 ? self.prefs : (() => {
   const defaults = {
     'openEditInWindow': false,      // new editor opens in a own browser window
     'windowPosition': {},           // detached window position

--- a/js/promisify.js
+++ b/js/promisify.js
@@ -1,4 +1,3 @@
-/* exported promisify */
 'use strict';
 /*
 Convert chrome APIs into promises. Example:
@@ -7,8 +6,8 @@ Convert chrome APIs into promises. Example:
   storageSyncGet(['key']).then(result => {...});
 
 */
-function promisify(fn) {
-  return (...args) =>
+self.promisify = self.INJECTED === 1 ? self.promisify : fn =>
+  (...args) =>
     new Promise((resolve, reject) => {
       fn(...args, (...result) => {
         if (chrome.runtime.lastError) {
@@ -21,4 +20,3 @@ function promisify(fn) {
         );
       });
     });
-}


### PR DESCRIPTION
Removes the page script, simplifies and speeds up style injection by using FF49+ wrappedJSObject to create style elements in page context, which is needed for Firefox (#461). But only if page CSP doesn't block inline styles.

Also disables the part of polyfill.js that's not used in content scripts or can't be used (like localStorage, which shouldn't be used by anything running in a worker, I hope, @eight04 ?).

P.S. Ideally all content scripts should be compiled/bundled into one script because currently the six content scripts may intertwine with site scripts (six scripts provide five opportunities for the browser to reschedule and postpone them) thus delaying style request and response. Stylus 1.4.22 was always sending the request in under 3ms after its start whereas now the six content scripts take at least 9ms, occasionally much more. Which allegedly increases the probability of FOUC on slower computers. Well, if people didn't complain then I guess it's kinda sorta okayish.