### PR TITLE
apply show-badge option to all tabs

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -134,7 +134,7 @@ prefs.subscribe([
 
 prefs.subscribe([
   'show-badge'
-], () => debounce(refreshIconBadgeText));
+], () => debounce(refreshAllIconsBadgeText));
 
 prefs.subscribe([
   'disableAll',


### PR DESCRIPTION
Repro:

1. open a tab with a few styles applied
2. right-click the Stylus toolbar icon
3. toggle "Show active style count"

Expected: the badge is toggled
Observed: nothing happens until the tab is reloaded

Also happens when changing the option in the options dialog.
It was broken in #518, and looks like a typo: `refreshAllIcons` should be `refreshAllIconsBadgeText`.