### PR TITLE
skip transition-patch in invisible tabs

### DIFF
--- a/content/style-injector.js
+++ b/content/style-injector.js
@@ -107,10 +107,12 @@ self.createStyleInjector = self.INJECTED === 1 ? self.createStyleInjector : ({
   }
 
   function _applyTransitionPatch(styles) {
+    isTransitionPatched = true;
     // CSS transition bug workaround: since we insert styles asynchronously,
     // the browsers, especially Firefox, may apply all transitions on page load
-    isTransitionPatched = document.readyState === 'complete';
-    if (isTransitionPatched || !styles.some(s => s.code.includes('transition'))) {
+    if (document.readyState === 'complete' ||
+        document.visibilityState === 'hidden' ||
+        !styles.some(s => s.code.includes('transition'))) {
       return;
     }
     const el = _createStyle(PATCH_ID, `


### PR DESCRIPTION
Closes #844.

After installing the style below the test case is as follows: 

1. open https://www.google.com/
2. switch to another tab in the same window
3. right-click the google's tab and click "reload"
4. wait a random amount of time and switch to google's tab 

Expected: no transitions on the red buttons

This is an old CSS we used to test the transition bug:

```css
/* ==UserStyle==
@name           !transition bug
@namespace      github.com/openstyles/stylus
@version        1.0.0
==/UserStyle== */
@-moz-document url-prefix("https://www.google.") {
    input[type="submit"] {
        -moz-appearance: none!important;
        background: red!important;
        transition: 1s !important;
    }

    input[type="submit"]:hover {
        background: cyan!important;
    }
}
```