### PR TITLE
show write-style entries for iframes in popup

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -49,10 +49,26 @@ window.API_METHODS = Object.assign(window.API_METHODS || {}, {
 
   openEditor,
 
-  // exposed for stuff that requires followup sendMessage() like popup::openSettings
-  // that would fail otherwise if another extension forced the tab to open
-  // in the foreground thus auto-closing the popup (in Chrome)
-  openURL,
+  /* Same as openURL, the only extra prop in `opts` is `message` - it'll be sent when the tab is ready,
+  which is needed in the popup, otherwise another extension could force the tab to open in foreground
+  thus auto-closing the popup (in Chrome at least) and preventing the sendMessage code from running */
+  openURL(opts) {
+    const {message} = opts;
+    return openURL(opts) // will pass the resolved value untouched when `message` is absent or falsy
+      .then(message && (tab => tab.status === 'complete' ? tab : onTabReady(tab)))
+      .then(message && (tab => msg.sendTab(tab.id, opts.message)));
+    function onTabReady(tab) {
+      return new Promise((resolve, reject) =>
+        setTimeout(function ping(numTries = 10, delay = 100) {
+          msg.sendTab(tab.id, {method: 'ping'})
+            .catch(() => false)
+            .then(pong => pong
+              ? resolve(tab)
+              : numTries && setTimeout(ping, delay, numTries - 1, delay * 1.5) ||
+                reject('timeout'));
+        }));
+    }
+  },
 
   optionsCustomizeHotkeys() {
     return browser.runtime.openOptionsPage()

--- a/background/background.js
+++ b/background/background.js
@@ -2,7 +2,7 @@
   URLS ignoreChromeError usercssHelper
   styleManager msg navigatorUtil workerUtil contentScripts sync
   findExistingTab createTab activateTab isTabReplaceable getActiveTab
-  iconManager tabManager */
+  tabManager */
 
 'use strict';
 
@@ -48,11 +48,6 @@ window.API_METHODS = Object.assign(window.API_METHODS || {}, {
   getPrefs: prefs.getAll,
 
   openEditor,
-
-  updateIconBadge(count) {
-    iconManager.updateIconBadge(this.sender.tab.id, count);
-    return true;
-  },
 
   // exposed for stuff that requires followup sendMessage() like popup::openSettings
   // that would fail otherwise if another extension forced the tab to open

--- a/background/icon-manager.js
+++ b/background/icon-manager.js
@@ -1,4 +1,4 @@
-/* global prefs debounce iconUtil FIREFOX CHROME VIVALDI tabManager API_METHODS */
+/* global prefs debounce iconUtil FIREFOX CHROME VIVALDI tabManager navigatorUtil API_METHODS */
 /* exported iconManager */
 'use strict';
 
@@ -35,6 +35,10 @@ const iconManager = (() => {
       refreshIconBadgeText(tabId);
       if (!frameId) refreshIcon(tabId, true);
     },
+  });
+
+  navigatorUtil.onCommitted(({tabId, frameId}) => {
+    if (!frameId) tabManager.set(tabId, 'styleIds', undefined);
   });
 
   function refreshIconBadgeText(tabId) {

--- a/background/icon-manager.js
+++ b/background/icon-manager.js
@@ -128,7 +128,9 @@ const iconManager = (() => {
   }
 
   function refreshStaleBadges() {
-    for (const tabId of staleBadges) refreshIconBadgeText(tabId);
+    for (const tabId of staleBadges) {
+      refreshIconBadgeText(tabId);
+    }
     staleBadges.clear();
   }
 })();

--- a/background/icon-manager.js
+++ b/background/icon-manager.js
@@ -28,13 +28,14 @@ const iconManager = (() => {
   });
 
   Object.assign(API_METHODS, {
-    /** @param {(number|string)[]} styleIds */
-    updateIconBadge(styleIds) {
+    /** @param {(number|string)[]} styleIds
+     * @param {boolean} [lazyBadge=false] preventing flicker during page load */
+    updateIconBadge(styleIds, {lazyBadge} = {}) {
       // FIXME: in some cases, we only have to redraw the badge. is it worth a optimization?
       const {frameId, tab: {id: tabId}} = this.sender;
       const value = styleIds.length ? styleIds.map(Number) : undefined;
       tabManager.set(tabId, 'styleIds', frameId, value);
-      debounce(refreshStaleBadges, frameId ? 250 : 0);
+      debounce(refreshStaleBadges, frameId && lazyBadge ? 250 : 0);
       staleBadges.add(tabId);
       if (!frameId) refreshIcon(tabId, true);
     },
@@ -52,7 +53,7 @@ const iconManager = (() => {
 
   function onPortDisconnected({sender}) {
     if (tabManager.get(sender.tab.id, 'styleIds')) {
-      API_METHODS.updateIconBadge.call({sender}, []);
+      API_METHODS.updateIconBadge.call({sender}, [], {lazyBadge: true});
     }
   }
 

--- a/background/style-via-api.js
+++ b/background/style-via-api.js
@@ -1,4 +1,4 @@
-/* global API_METHODS styleManager CHROME prefs iconManager */
+/* global API_METHODS styleManager CHROME prefs */
 'use strict';
 
 API_METHODS.styleViaAPI = !CHROME && (() => {
@@ -31,12 +31,13 @@ API_METHODS.styleViaAPI = !CHROME && (() => {
         .then(maybeToggleObserver);
   };
 
-  function updateCount(request, {tab, frameId}) {
+  function updateCount(request, sender) {
+    const {tab, frameId} = sender;
     if (frameId) {
       throw new Error('we do not count styles for frames');
     }
     const {frameStyles} = getCachedData(tab.id, frameId);
-    iconManager.updateIconBadge(tab.id, Object.keys(frameStyles).length);
+    API_METHODS.updateIconBadge.call({sender}, Object.keys(frameStyles));
   }
 
   function styleApply({id = null, ignoreUrlCheck = false}, {tab, frameId, url}) {

--- a/background/tab-manager.js
+++ b/background/tab-manager.js
@@ -24,17 +24,28 @@ const tabManager = (() => {
     onUpdate(fn) {
       listeners.push(fn);
     },
-    get(tabId, key) {
-      const meta = cache.get(tabId);
-      return meta && meta[key];
+    get(tabId, ...keys) {
+      return keys.reduce((meta, key) => meta && meta[key], cache.get(tabId));
     },
-    set(tabId, key, value) {
+    /**
+     * number of keys is arbitrary, last arg is value, `undefined` will delete the last key from meta
+     * (tabId, 'foo', 123) will set tabId's meta to {foo: 123},
+     * (tabId, 'foo', 'bar', 'etc', 123) will set tabId's meta to {foo: {bar: {etc: 123}}}
+     */
+    set(tabId, ...args) {
       let meta = cache.get(tabId);
       if (!meta) {
         meta = {};
         cache.set(tabId, meta);
       }
-      meta[key] = value;
+      const value = args.pop();
+      const lastKey = args.pop();
+      for (const key of args) meta = meta[key] || (meta[key] = {});
+      if (value === undefined) {
+        delete meta[lastKey];
+      } else {
+        meta[lastKey] = value;
+      }
     },
     list() {
       return cache.keys();

--- a/content/apply.js
+++ b/content/apply.js
@@ -18,7 +18,12 @@ self.INJECTED !== 1 && (() => {
 
   // if chrome.tabs is absent it's a web page, otherwise we'll check for popup/options as those aren't tabs
   let isTab = !chrome.tabs;
-  if (chrome.tabs) chrome.tabs.getCurrent(tab => (isTab = Boolean(tab)));
+  if (chrome.tabs) {
+    chrome.tabs.getCurrent(tab => {
+      isTab = Boolean(tab);
+      if (tab && styleInjector.list.length) updateCount();
+    });
+  }
 
   // save it now because chrome.runtime will be unavailable in the orphaned script
   const orphanEventId = chrome.runtime.id;

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -1,4 +1,4 @@
-/* exported getActiveTab onTabReady stringAsRegExp getTabRealURL openURL
+/* exported getActiveTab onTabReady stringAsRegExp openURL
   getStyleWithNoCode tryRegExp sessionStorageHash download deepEqual
   closeCurrentTab capitalize CHROME_HAS_BORDER_BUG */
 /* global promisify */
@@ -123,18 +123,6 @@ function getOwnTab() {
 function getActiveTab() {
   return queryTabs({currentWindow: true, active: true})
     .then(tabs => tabs[0]);
-}
-
-function getTabRealURL(tab) {
-  return new Promise(resolve => {
-    if (tab.url !== 'chrome://newtab/' || URLS.chromeProtectsNTP) {
-      resolve(tab.url);
-    } else {
-      chrome.webNavigation.getFrame({tabId: tab.id, frameId: 0, processId: -1}, frame => {
-        resolve(frame && frame.url || '');
-      });
-    }
-  });
 }
 
 /**

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -1,4 +1,4 @@
-/* exported getActiveTab onTabReady stringAsRegExp openURL
+/* exported getTab getActiveTab onTabReady stringAsRegExp openURL ignoreChromeError
   getStyleWithNoCode tryRegExp sessionStorageHash download deepEqual
   closeCurrentTab capitalize CHROME_HAS_BORDER_BUG */
 /* global promisify */
@@ -123,70 +123,6 @@ function getOwnTab() {
 function getActiveTab() {
   return queryTabs({currentWindow: true, active: true})
     .then(tabs => tabs[0]);
-}
-
-/**
- * Resolves when the [just created] tab is ready for communication.
- * @param {Number|Tab} tabOrId
- * @returns {Promise<?Tab>}
- */
-function onTabReady(tabOrId) {
-  let tabId, tab;
-  if (Number.isInteger(tabOrId)) {
-    tabId = tabOrId;
-  } else {
-    tab = tabOrId;
-    tabId = tab && tab.id;
-  }
-  if (!tab) {
-    return getTab(tabId).then(onTabReady);
-  }
-  if (tab.status === 'complete') {
-    if (!FIREFOX || tab.url !== 'about:blank') {
-      return Promise.resolve(tab);
-    } else {
-      return new Promise(resolve => {
-        chrome.webNavigation.getFrame({tabId, frameId: 0}, frame => {
-          ignoreChromeError();
-          if (frame) {
-            onTabReady(tab).then(resolve);
-          } else {
-            setTimeout(() => onTabReady(tabId).then(resolve));
-          }
-        });
-      });
-    }
-  }
-  return new Promise((resolve, reject) => {
-    chrome.webNavigation.onCommitted.addListener(onCommitted);
-    chrome.webNavigation.onErrorOccurred.addListener(onErrorOccurred);
-    chrome.tabs.onRemoved.addListener(onTabRemoved);
-    chrome.tabs.onReplaced.addListener(onTabReplaced);
-    function onCommitted(info) {
-      if (info.tabId !== tabId) return;
-      unregister();
-      getTab(tab.id).then(resolve);
-    }
-    function onErrorOccurred(info) {
-      if (info.tabId !== tabId) return;
-      unregister();
-      reject();
-    }
-    function onTabRemoved(removedTabId) {
-      if (removedTabId !== tabId) return;
-      unregister();
-      reject();
-    }
-    function onTabReplaced(addedTabId, removedTabId) {
-      onTabRemoved(removedTabId);
-    }
-    function unregister() {
-      chrome.webNavigation.onCommitted.removeListener(onCommitted);
-      chrome.webNavigation.onErrorOccurred.removeListener(onErrorOccurred);
-      chrome.tabs.onRemoved.removeListener(onTabRemoved);
-      chrome.tabs.onReplaced.removeListener(onTabReplaced);
-    }
-  });
 }
 
 function urlToMatchPattern(url, ignoreSearch) {

--- a/popup.html
+++ b/popup.html
@@ -235,6 +235,7 @@
         </span>
       </div>
       <div id="write-style">
+        <a id="write-for-frames" href="#" title="<IFRAME>..." hidden></a>
         <span id="write-style-for" i18n-text="writeStyleFor"></span>
       </div>
     </div>

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -313,6 +313,15 @@ a.configure[target="_blank"] .svg-icon.config {
   color: darkred;
 }
 
+.frame-url::before {
+  content: "iframe: ";
+  color: lightslategray;
+}
+
+.frame .style-name {
+  font-weight: normal;
+}
+
 /* entry menu */
 .entry .menu {
   display: none;
@@ -516,11 +525,79 @@ body.blocked .actions > .main-controls {
   content: "\00ad"; /* "soft" hyphen */
 }
 
-#match {
+.about-blank > .breadcrumbs {
+  pointer-events: none;
+}
+
+.about-blank > .breadcrumbs a {
+  text-decoration: none;
+}
+
+.match {
   overflow-wrap: break-word;
   display: block;
   flex-grow: 9;
+}
+
+.match[data-frame-id="0"] {
   min-width: 200px;
+}
+
+.match[data-frame-id="0"] > .match {
+  margin-top: .25em;
+}
+
+.match .match {
+  margin-left: .5rem;
+}
+
+.match .match::before {
+  content: "";
+  width: .25rem;
+  height: .25rem;
+  margin-left: -.5rem;
+  display: block;
+  position: absolute;
+  border-width: 1px;
+  border-style: none none solid solid;
+}
+
+.dupe > .breadcrumbs {
+  opacity: .5;
+}
+
+.dupe:not([data-children]) {
+  display: none;
+}
+
+#write-for-frames {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  margin-left: -12px;
+  margin-top: 4px;
+  --dash: transparent 2px, currentColor 2px, currentColor 3px, transparent 3px;
+  background: linear-gradient(var(--dash)), linear-gradient(90deg, var(--dash));
+}
+
+#write-for-frames.expanded {
+  background: linear-gradient(var(--dash));
+}
+
+#write-for-frames::after {
+  position: absolute;
+  margin: -2px;
+  border: 1px solid currentColor;
+  content: "";
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+#write-for-frames:not(.expanded) ~ .match:not([data-frame-id="0"]),
+#write-for-frames:not(.expanded) ~ .match .match {
+  display: none;
 }
 
 /* "breadcrumbs" 'new style' links */

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -547,6 +547,10 @@ body.blocked .actions > .main-controls {
   margin-top: .25em;
 }
 
+.match:not([data-frame-id="0"]) a {
+  text-decoration: none; /* not underlining iframe links until hovered to reduce visual noise */
+}
+
 .match .match {
   margin-left: .5rem;
 }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -8,12 +8,6 @@
   --outer-padding: 9px;
 }
 
-html {
-  /* Chrome 66-?? adds a gap equal to the scrollbar width,
-     which looks like a bug, see https://crbug.com/821143 */
-  overflow: overlay;
-}
-
 html, body {
   height: min-content;
   max-height: 600px;

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -312,7 +312,7 @@ function sortStyles(entries) {
 
 function showStyles(frameResults) {
   const entries = new Map();
-  frameResults.forEach(({styles, url}, index) => {
+  frameResults.forEach(({styles = [], url}, index) => {
     styles.forEach(style => {
       const {id} = style.data;
       if (!entries.has(id)) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,5 +1,5 @@
 /* global configDialog hotkeys msg
-  getActiveTab FIREFOX URLS API onDOMready $ $$ prefs
+  getActiveTab CHROME FIREFOX URLS API onDOMready $ $$ prefs
   setupLivePrefs template t $create animateElement
   tryJSONparse CHROME_HAS_BORDER_BUG */
 
@@ -14,6 +14,10 @@ const handleEvent = {};
 const ABOUT_BLANK = 'about:blank';
 const ENTRY_ID_PREFIX_RAW = 'style-';
 const ENTRY_ID_PREFIX = '#' + ENTRY_ID_PREFIX_RAW;
+
+if (CHROME >= 3345 && CHROME < 3533) { // Chrome 66-69 adds a gap, https://crbug.com/821143
+  document.head.appendChild($create('style', 'html { overflow: overlay }'));
+}
 
 toggleSideBorders();
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -219,6 +219,7 @@ function sortTabFrames(frames) {
   const sortedFrames = [...known.values(), ...unknown.values()];
   const urls = new Set([ABOUT_BLANK]);
   for (const f of sortedFrames) {
+    f.url = f.url || '';
     f.isDupe = urls.has(f.url);
     urls.add(f.url);
   }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -210,8 +210,8 @@ function sortTabFrames(frames) {
   while (unknown.size !== lastSize) {
     for (const [frameId, f] of unknown) {
       if (known.has(f.parentFrameId)) {
-        known.set(frameId, f);
         unknown.delete(frameId);
+        if (!f.errorOccurred) known.set(frameId, f);
         if (f.url === ABOUT_BLANK) f.url = known.get(f.parentFrameId).url;
       }
     }


### PR DESCRIPTION
Closes #191.

If the site has iframes a `[+]` toggle is shown to the left of the #write-style block.

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
  ![image](https://user-images.githubusercontent.com/1310400/74974574-8e43da00-5436-11ea-8214-4c65971aafed.png)
  ![image](https://user-images.githubusercontent.com/1310400/74974597-9865d880-5436-11ea-8607-569ed7d2a228.png)

* https://css-tricks.com/responsive-iframes/
  ![image](https://user-images.githubusercontent.com/1310400/74975214-c3046100-5437-11ea-820a-cb3b74245a37.png)

* https://www.tutorialrepublic.com/html-tutorial/html-iframes.php
  ![image](https://user-images.githubusercontent.com/1310400/74974519-74a29280-5436-11ea-810d-def86a1aaf87.png)

Styles for iframes are shown in the list and counted in the badge text.