### PR TITLE
fix category check when searching for `foo.bar.tld`

### DIFF
--- a/popup/search-results.js
+++ b/popup/search-results.js
@@ -623,7 +623,7 @@ window.addEventListener('showStyles:done', function _() {
         fourth ||
         third && third !== 'www' && third !== 'm'
       );
-      return (keepThird && `${third}.` || '') + main + (keepTld ? `.${tld}` : '');
+      return (keepThird && `${third}.` || '') + main + (keepTld || keepThird ? `.${tld}` : '');
     }
   }
 
@@ -632,7 +632,7 @@ window.addEventListener('showStyles:done', function _() {
       result.subcategory &&
       !processedResults.some(pr => pr.id === result.id) &&
       (category !== STYLUS_CATEGORY || /\bStylus\b/i.test(result.name + result.description)) &&
-      category.split('.')[0] === result.subcategory.split('.')[0]
+      category.split('.').includes(result.subcategory.split('.')[0])
     );
   }
 


### PR DESCRIPTION
Example URL: https://developers.google.com/web/updates/2020/02/twa-lay-of-the-land

Currently searching for `foo.bar.com` strips `com`, tries `foo.bar`, and fails.
It will look for the entire thing now in the first try.