### PR TITLE
Contributing.md - Fix Build.md link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ You can help us translate the extension on [Transifex](https://www.transifex.com
 
 ## Build scripts
 
-See [Build.md](../Build.md) for more information.
+See [BUILD.md](../BUILD.md) for more information.
 
 ## Contact us
 


### PR DESCRIPTION
The non Capitalized link will give you the 404 page not found error.
[Wrong link Current one 		Build.md](https://github.com/openstyles/stylus/blob/master/Build.md)
[Correct link Commited one 		BUILD.md](https://github.com/openstyles/stylus/blob/master/BUILD.md)