### PR TITLE
Fix missing CWS page icon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,10 +6,10 @@
   "homepage_url": "https://add0n.com/stylus.html",
   "manifest_version": 2,
   "icons": {
-    "16": "/images/icon/16.png",
-    "32": "/images/icon/32.png",
-    "48": "/images/icon/48.png",
-    "128": "/images/icon/128.png"
+    "16": "images/icon/16.png",
+    "32": "images/icon/32.png",
+    "48": "images/icon/48.png",
+    "128": "images/icon/128.png"
   },
   "permissions": [
     "tabs",
@@ -98,10 +98,10 @@
   ],
   "browser_action": {
     "default_icon": {
-      "16": "/images/icon/16w.png",
-      "32": "/images/icon/32w.png",
-      "19": "/images/icon/19w.png",
-      "38": "/images/icon/38w.png"
+      "16": "images/icon/16w.png",
+      "32": "images/icon/32w.png",
+      "19": "images/icon/19w.png",
+      "38": "images/icon/38w.png"
     },
     "default_title": "Stylus",
     "default_popup": "popup.html"


### PR DESCRIPTION
Apparently, some genius decided to arbitrarily make a breaking change for no reason. I'm not positive this will fix it, but this seems to be [the advice they're giving people](https://groups.google.com/a/chromium.org/d/msg/chromium-extensions/JnyoH2Ix0H0/ZovG6ggwAgAJ).