### PR TITLE
Add unlimitedStorage permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
     "webRequestBlocking",
     "contextMenus",
     "storage",
+    "unlimitedStorage",
     "alarms",
     "identity",
     "<all_urls>"


### PR DESCRIPTION
IndexedDB storage [may be evicted by the browser at its discretion][1]. Granting the unlimitedStorage permission [ensures that IndexedDB data will not be evicted][2], and [allows the extension to store more than 5MB of data if needed][3].

This is the root cause of how my IndexedDB got "corrupted" one time, as my storage filled up temporarily - causing Stylus's IndexedDB to be evicted. FWIW, Tampermonkey (a similar manager for userscripts) uses the same permission, so it's probably safe to use for Stylus.

[1]: https://web.dev/storage-for-the-web/#eviction
[2]: https://crbug.com/680392#c5
[3]: https://developer.chrome.com/apps/declare_permissions#unlimitedStorage