### PR TITLE
use major browser version in CHROME constant

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -217,7 +217,7 @@ function createContextMenus(ids) {
 
 if (chrome.contextMenus) {
   // circumvent the bug with disabling check marks in Chrome 62-64
-  const toggleCheckmark = CHROME >= 3172 && CHROME <= 3288 ?
+  const toggleCheckmark = CHROME >= 62 && CHROME <= 64 ?
     (id => chrome.contextMenus.remove(id, () => createContextMenus([id]) + ignoreChromeError())) :
     ((id, checked) => chrome.contextMenus.update(id, {checked}, ignoreChromeError));
 

--- a/background/icon-manager.js
+++ b/background/icon-manager.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const iconManager = (() => {
-  const ICON_SIZES = FIREFOX || CHROME >= 2883 && !VIVALDI ? [16, 32] : [19, 38];
+  const ICON_SIZES = FIREFOX || CHROME >= 55 && !VIVALDI ? [16, 32] : [19, 38];
   const staleBadges = new Set();
 
   prefs.subscribe([

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -4,15 +4,13 @@
 /* global promisify */
 'use strict';
 
-const CHROME = Boolean(chrome.app) && parseInt(navigator.userAgent.match(/Chrom\w+\/(?:\d+\.){2}(\d+)|$/)[1]);
+const CHROME = Boolean(chrome.app) && parseInt(navigator.userAgent.match(/Chrom\w+\/(\d+)|$/)[1]);
 const OPERA = Boolean(chrome.app) && parseFloat(navigator.userAgent.match(/\bOPR\/(\d+\.\d+)|$/)[1]);
 const VIVALDI = Boolean(chrome.app) && navigator.userAgent.includes('Vivaldi');
-// FIXME: who use this?
-// const ANDROID = !chrome.windows;
 let FIREFOX = !chrome.app && parseFloat(navigator.userAgent.match(/\bFirefox\/(\d+\.\d+)|$/)[1]);
 
 // see PR #781
-const CHROME_HAS_BORDER_BUG = CHROME >= 3167 && CHROME <= 3704;
+const CHROME_HAS_BORDER_BUG = CHROME >= 62 && CHROME <= 74;
 
 if (!CHROME && !chrome.browserAction.openPopup) {
   // in FF pre-57 legacy addons can override useragent so we assume the worst
@@ -62,7 +60,7 @@ const URLS = {
 
   // Chrome 61.0.3161+ doesn't run content scripts on NTP https://crrev.com/2978953002/
   // TODO: remove when "minimum_chrome_version": "61" or higher
-  chromeProtectsNTP: CHROME >= 3161,
+  chromeProtectsNTP: CHROME >= 61,
 
   userstylesOrgJson: 'https://userstyles.org/styles/chrome/',
 

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -625,7 +625,7 @@ function switchUI({styleOnly} = {}) {
       filter: none;
       opacity: 1;
     }
-  `) + (CHROME >= 3004 ? `
+  `) + (CHROME >= 58 ? `
     .newUI .entry {
       contain: strict;
     }

--- a/options/options.js
+++ b/options/options.js
@@ -10,7 +10,7 @@ enforceInputRange($('#popupWidth'));
 setTimeout(splitLongTooltips);
 
 // https://github.com/openstyles/stylus/issues/822
-if (!FIREFOX && CHROME >= 3809 && CHROME < 4044) {
+if (!FIREFOX && CHROME >= 76 && CHROME <= 81) {
   const dropboxOption = $('option[value="dropbox"]');
   dropboxOption.disabled = true;
   dropboxOption.setAttribute('title', t('hostDisabled'));
@@ -24,7 +24,7 @@ if (CHROME_HAS_BORDER_BUG) {
 }
 
 // collapse #advanced block in Chrome pre-66 (classic chrome://extensions UI)
-if (!FIREFOX && !OPERA && CHROME < 3343) {
+if (!FIREFOX && !OPERA && CHROME < 66) {
   const block = $('#advanced');
   $('h1', block).onclick = event => {
     event.preventDefault();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -15,7 +15,7 @@ const ABOUT_BLANK = 'about:blank';
 const ENTRY_ID_PREFIX_RAW = 'style-';
 const ENTRY_ID_PREFIX = '#' + ENTRY_ID_PREFIX_RAW;
 
-if (CHROME >= 3345 && CHROME < 3533) { // Chrome 66-69 adds a gap, https://crbug.com/821143
+if (CHROME >= 66 && CHROME <= 69) { // Chrome 66-69 adds a gap, https://crbug.com/821143
   document.head.appendChild($create('style', 'html { overflow: overlay }'));
 }
 


### PR DESCRIPTION
Fixes #943, assuming Chrome will expose only the major browser version in its UA string.

Another solution/workaround that I rejected is to use feature detection based on https://www.chromestatus.com/features but it's really not that straightforward because some features were added in earlier versions of Chrome and were hidden under some flag, for example behind the "experimental web platform features" flag often enabled by people for kicks.