### PR TITLE
show sublime bookmarks

### DIFF
--- a/edit/codemirror-default.css
+++ b/edit/codemirror-default.css
@@ -18,6 +18,12 @@
   outline: -webkit-focus-ring-color auto 5px;
   outline-offset: -2px;
 }
+.CodeMirror-bookmark {
+  background: linear-gradient(to right, currentColor, transparent);
+  position: absolute;
+  width: 2em;
+  opacity: .5;
+}
 @supports (-moz-appearance:none) {
   /* restrict to FF */
   .CodeMirror-focused {

--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -242,23 +242,6 @@
     CodeMirror.commands[name] = (...args) => editor[name](...args);
   }
 
-  // speedup: reuse the old folding marks
-  // TODO: remove when https://github.com/codemirror/CodeMirror/pull/6010 is shipped in /vendor
-  const {setGutterMarker} = CodeMirror.prototype;
-  CodeMirror.prototype.setGutterMarker = function (line, gutterID, value) {
-    const o = this.state.foldGutter.options;
-    if (typeof o.indicatorOpen === 'string' ||
-        typeof o.indicatorFolded === 'string') {
-      const old = line.gutterMarkers && line.gutterMarkers[gutterID];
-      // old className can contain other names set by CodeMirror so we'll use classList
-      if (old && value && old.classList.contains(value.className) ||
-          !old && !value) {
-        return line;
-      }
-    }
-    return setGutterMarker.apply(this, arguments);
-  };
-
   // CodeMirror convenience commands
   Object.assign(CodeMirror.commands, {
     toggleEditorFocus,


### PR DESCRIPTION
* Implements #949 since CodeMirror's author doesn't want to. The default style is really primitive: it's a gradient from currentColor to transparent over the line number.

* Removes the no longer needed optimization which is included in CodeMirror.