### PR TITLE
Improve delete confirmation autofocus visual indication

### DIFF
--- a/manage/manage.js
+++ b/manage/manage.js
@@ -454,6 +454,8 @@ Object.assign(handleEvent, {
         API.deleteStyle(id);
       }
     });
+    const deleteButton = $('#message-box-buttons > button');
+    if (deleteButton) deleteButton.removeAttribute('data-focused-via-click');
   },
 
   external(event) {

--- a/msgbox/msgbox.css
+++ b/msgbox/msgbox.css
@@ -134,6 +134,15 @@
   text-align: center;
 }
 
+.danger #message-box-buttons > button:not([data-focused-via-click]):first-child:focus {
+  outline: red auto 1px;
+}
+
+/* FF ignores color with 'auto' */
+.firefox .danger #message-box-buttons > button:not([data-focused-via-click]):first-child:focus {
+  outline: red solid 1px;
+}
+
 .non-windows #message-box-buttons {
   text-align: right;
   direction: rtl;

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -341,6 +341,13 @@ a.configure[target="_blank"] .svg-icon.config {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+#confirm button[data-cmd="ok"]:not([data-focused-via-click]):focus {
+  outline: red auto 1px;
+}
+/* FF ignores color with 'auto' */
+.firefox #confirm button[data-cmd="ok"]:not([data-focused-via-click]):focus {
+  outline: red solid 1px;
+}
 .menu-items-wrapper {
   width: 80%;
   max-height: 80%;


### PR DESCRIPTION
![delete](https://user-images.githubusercontent.com/14100003/83466819-47f31380-a446-11ea-9abf-5897940294b4.png)

I did miss this point in the [OP](https://github.com/openstyles/stylus/issues/954), mostly because my personal style hides focus outlines anyway. The delete button is also focused when the manager confirmation dialog appears, but it seems like our 'focused-via-click' hack is interfering with this particular focus outline.

This PR fixes that, and makes these focus outlines red for good measure.

@tophf if you'd prefer to tweak the accessibility hack, feel free, but I'm not screwing around with it.