### PR TITLE
add a hotkey & right-click to beautify silently

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1273,6 +1273,10 @@
     "message": "Beautify",
     "description": "Label for the CSS-beautifier button on the edit style page"
   },
+  "styleBeautifyHint": {
+    "message": "Hint: right-click the “Beautify” button or use the keyboard shortcut defined below to beautify without showing this panel",
+    "description": "Hint shown inside the CSS-beautifier panel"
+  },
   "styleBeautifyIndentConditional": {
     "message": "Indent @media, @supports",
     "description": "CSS-beautifier option"

--- a/edit/colorpicker-helper.js
+++ b/edit/colorpicker-helper.js
@@ -1,4 +1,4 @@
-/* global CodeMirror showHelp cmFactory onDOMready $ $create prefs t */
+/* global CodeMirror showHelp cmFactory onDOMready $ prefs t createHotkeyInput */
 'use strict';
 
 (() => {
@@ -62,46 +62,8 @@
 
   function configureColorpicker(event) {
     event.preventDefault();
-    const input = $create('input', {
-      type: 'search',
-      spellcheck: false,
-      value: prefs.get('editor.colorpicker.hotkey'),
-      onkeydown(event) {
-        event.preventDefault();
-        event.stopPropagation();
-        const key = CodeMirror.keyName(event);
-        switch (key) {
-          case 'Enter':
-            if (this.checkValidity()) {
-              $('#help-popup .dismiss').onclick();
-            }
-            return;
-          case 'Esc':
-            $('#help-popup .dismiss').onclick();
-            return;
-          default:
-            // disallow: [Shift?] characters, modifiers-only, [modifiers?] + Esc, Tab, nav keys
-            if (!key || new RegExp('^(' + [
-              '(Back)?Space',
-              '(Shift-)?.', // a single character
-              '(Shift-?|Ctrl-?|Alt-?|Cmd-?){0,2}(|Esc|Tab|(Page)?(Up|Down)|Left|Right|Home|End|Insert|Delete)',
-            ].join('|') + ')$', 'i').test(key)) {
-              this.value = key || this.value;
-              this.setCustomValidity('Not allowed');
-              return;
-            }
-        }
-        this.value = key;
-        this.setCustomValidity('');
-        prefs.set('editor.colorpicker.hotkey', key);
-      },
-      oninput() {
-        // fired on pressing "x" to clear the field
-        prefs.set('editor.colorpicker.hotkey', '');
-      },
-      onpaste(event) {
-        event.preventDefault();
-      }
+    const input = createHotkeyInput('editor.colorpicker.hotkey', () => {
+      $('#help-popup .dismiss').onclick();
     });
     const popup = showHelp(t('helpKeyMapHotkey'), input);
     if (this instanceof Element) {

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -779,6 +779,11 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   padding-left: 4px;
   margin-left: 4px;
 }
+.beautify-hint {
+  width: 0;
+  min-width: 100%;
+  font-size: 90%;
+}
 
 /************ single editor **************/
 .usercss body {

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -1,7 +1,7 @@
 /* global CodeMirror onDOMready prefs setupLivePrefs $ $$ $create t tHTML
   createSourceEditor queryTabs sessionStorageHash getOwnTab FIREFOX API tryCatch
   closeCurrentTab messageBox debounce workerUtil
-  beautify ignoreChromeError
+  initBeautifyButton ignoreChromeError
   moveFocus msg createSectionsEditor rerouteHotkeys CODEMIRROR_THEMES */
 /* exported showCodeMirrorPopup editorWorker toggleContextMenuDelete */
 'use strict';
@@ -170,10 +170,8 @@ preinit();
         $('#heading').textContent = t(style.id ? 'editStyleHeading' : 'addStyleTitle');
         $('#name').placeholder = t(usercss ? 'usercssEditorNamePlaceholder' : 'styleMissingName');
         $('#name').title = usercss ? t('usercssReplaceTemplateName') : '';
-
         $('#preview-label').classList.toggle('hidden', !style.id);
-
-        $('#beautify').onclick = () => beautify(editor.getEditors());
+        initBeautifyButton($('#beautify'), () => editor.getEditors());
         window.addEventListener('resize', () => {
           debounce(rememberWindowSize, 100);
           detectLayout();

--- a/edit/reroute-hotkeys.js
+++ b/edit/reroute-hotkeys.js
@@ -12,6 +12,7 @@ const rerouteHotkeys = (() => {
     'toggleEditorFocus',
     'find', 'findNext', 'findPrev', 'replace', 'replaceAll',
     'colorpicker',
+    'beautify',
   ]);
 
   return rerouteHotkeys;

--- a/edit/sections-editor-section.js
+++ b/edit/sections-editor-section.js
@@ -94,6 +94,7 @@ function createSection({
   const cm = cmFactory.create(wrapper => {
     el.insertBefore(wrapper, $('.code-label', el).nextSibling);
   }, {value: originalSection.code});
+  el.CodeMirror = cm; // used by getAssociatedEditor
 
   const changeListeners = new Set();
 

--- a/edit/sections-editor-section.js
+++ b/edit/sections-editor-section.js
@@ -1,5 +1,5 @@
 /* global template cmFactory $ propertyToCss CssToProperty linter regExpTester
-  FIREFOX toggleContextMenuDelete beautify showHelp t tryRegExp */
+  FIREFOX toggleContextMenuDelete initBeautifyButton showHelp t tryRegExp */
 /* exported createSection */
 'use strict';
 
@@ -196,12 +196,12 @@ function createSection({
     $('.clone-section', el).addEventListener('click', () => insertSectionAfter(getModel(), section));
     $('.move-section-up', el).addEventListener('click', () => moveSectionUp(section));
     $('.move-section-down', el).addEventListener('click', () => moveSectionDown(section));
-    $('.beautify-section', el).addEventListener('click', () => beautify([cm]));
     $('.restore-section', el).addEventListener('click', () => restoreSection(section));
     $('.test-regexp', el).addEventListener('click', () => {
       regExpTester.toggle();
       updateRegexpTester();
     });
+    initBeautifyButton($('.beautify-section', el), () => [cm]);
   }
 
   function handleKeydown(cm, event) {

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -154,9 +154,7 @@ function createSectionsEditor({style, onTitleChanged}) {
   function closestVisible(nearbyElement) {
     const cm =
       nearbyElement instanceof CodeMirror ? nearbyElement :
-      nearbyElement instanceof Node &&
-        (nearbyElement.closest('#sections > .section') || {}).CodeMirror ||
-      getLastActivatedEditor();
+        nearbyElement instanceof Node && getAssociatedEditor(nearbyElement) || getLastActivatedEditor();
     if (nearbyElement instanceof Node && cm) {
       const {left, top} = nearbyElement.getBoundingClientRect();
       const bounds = cm.display.wrapper.getBoundingClientRect();
@@ -225,6 +223,15 @@ function createSectionsEditor({style, onTitleChanged}) {
         scrollToEditor(cm);
       }
       return cm;
+    }
+  }
+
+  function getAssociatedEditor(nearbyElement) {
+    for (let el = nearbyElement; el; el = el.parentElement) {
+      // added by createSection
+      if (el.CodeMirror) {
+        return el.CodeMirror;
+      }
     }
   }
 

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -59,6 +59,7 @@ self.prefs = self.INJECTED === 1 ? self.prefs : (() => {
       end_with_newline: false,
       indent_conditional: true,
     },
+    'editor.beautify.hotkey': '',
     'editor.lintDelay': 300,        // lint gutter marker update delay, ms
     'editor.linter': 'csslint',     // 'csslint' or 'stylelint' or ''
     'editor.lintReportDelay': 500,  // lint report update delay, ms


### PR DESCRIPTION
Fixes #970.

Pressing a configurable hotkey or right-clicking the Beautify button will perform beautification silently i.e. without showing the dialog. This info and the hotkey input itself are shown at the bottom of the beautify panel.