### PR TITLE
when sorting on updateDate use installDate as a fallback

### DIFF
--- a/manage/sort.js
+++ b/manage/sort.js
@@ -32,7 +32,7 @@ const sorter = (() => {
     },
     dateUpdated: {
       text: t('dateUpdated'),
-      parse: ({style}) => style.updateDate,
+      parse: ({style}) => style.updateDate || style.installDate,
       sorter: sorterType.number
     }
   };


### PR DESCRIPTION
Previously, when sorting by updateDate the newly installed styles weren't on top, which felt wrong.