### PR TITLE
prolong worker lifetime to 5 minutes

### DIFF
--- a/js/worker-util.js
+++ b/js/worker-util.js
@@ -6,7 +6,7 @@ const workerUtil = (() => {
   const loadedScripts = new Set();
   return {createWorker, createAPI, loadScript, cloneError};
 
-  function createWorker({url, lifeTime = 30}) {
+  function createWorker({url, lifeTime = 300}) {
     let worker;
     let id;
     let timer;


### PR DESCRIPTION
This PR prolongs the linter worker lifetime from 30 seconds to 5 minutes. Both in the editor tab and in the background script. Currently, the worker restarts **a lot** when working on a style for a long time. Each restart stresses the CPU to perform code compilation/analysis, and obliterates the purpose of the parser cache in CSSLint that normally provides up to 10x speedup.