### PR TITLE
fix column combinator detection

### DIFF
--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -2953,8 +2953,10 @@ self.parserlib = (() => {
         case '$':
         case '*':
           return (
-            reader.peek() === '=' ? this.comparisonToken(c, pos) :
-            reader.readMatch('|') ? this.createToken(Tokens.COLUMN, '||', pos) :
+            reader.peek() === '=' ?
+              this.comparisonToken(c, pos) :
+            c === '|' && reader.readMatch('|') ?
+              this.createToken(Tokens.COLUMN, '||', pos) :
               this.charToken(c, pos)
           );
         /*


### PR DESCRIPTION
Follow-up to #981 fixing the check for `||` combinator.