### PR TITLE
restore Shift-Ctrl-Wheel to scroll window in multi-section mode

### DIFF
--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -34,7 +34,8 @@ function createSectionsEditor({style, onTitleChanged}) {
   $('#from-mozilla').addEventListener('click', () => showMozillaFormatImport());
   $('#save-button').addEventListener('click', saveStyle);
 
-  document.addEventListener('wheel', scrollEntirePageOnCtrlShift);
+  document.addEventListener('wheel', scrollEntirePageOnCtrlShift, {passive: false});
+  CodeMirror.defaults.extraKeys['Shift-Ctrl-Wheel'] = 'scrollWindow';
 
   if (!FIREFOX) {
     $$([

--- a/edit/show-keymap-help.js
+++ b/edit/show-keymap-help.js
@@ -10,7 +10,6 @@ function showKeyMapHelp() {
   const keyMap = mergeKeyMaps({}, prefs.get('editor.keyMap'), CodeMirror.defaults.extraKeys);
   const keyMapSorted = Object.keys(keyMap)
     .map(key => ({key, cmd: keyMap[key]}))
-    .concat([{key: 'Shift-Ctrl-Wheel', cmd: 'scrollWindow'}])
     .sort((a, b) => (a.cmd < b.cmd || (a.cmd === b.cmd && a.key < b.key) ? -1 : 1));
   const table = template.keymapHelp.cloneNode(true);
   const tBody = table.tBodies[0];


### PR DESCRIPTION
The bug was mentioned in #1004.

In new Chrome we should register document-level scroll listeners as non-passive explicitly.

I've also removed this hotkey from the keymap help in usercss mode because it's not registered there (no need).