### PR TITLE
use onBoundsChanged to remember editor size/position

### DIFF
--- a/edit/edit.js
+++ b/edit/edit.js
@@ -172,8 +172,19 @@ preinit();
         $('#name').title = usercss ? t('usercssReplaceTemplateName') : '';
         $('#preview-label').classList.toggle('hidden', !style.id);
         initBeautifyButton($('#beautify'), () => editor.getEditors());
+        const {onBoundsChanged} = chrome.windows || {};
+        if (onBoundsChanged) {
+          // * movement is reported even if the window wasn't resized
+          // * fired just once when done so debounce is not needed
+          onBoundsChanged.addListener(wnd => {
+            // getting the current window id as it may change if the user attached/detached the tab
+            chrome.windows.getCurrent(ownWnd => {
+              if (wnd.id === ownWnd.id) rememberWindowSize();
+            });
+          });
+        }
         window.addEventListener('resize', () => {
-          debounce(rememberWindowSize, 100);
+          if (!onBoundsChanged) debounce(rememberWindowSize, 100);
           detectLayout();
         });
         detectLayout();


### PR DESCRIPTION
Unlike DOM `resize` event, this one also reports movement even if not resized.

Currently available in a) the latest chromium snapshot from https://download-chromium.appspot.com or b) Chrome Canary that's based on revision greater than 793515 per https://omahaproxy.appspot.com, which should be its next update.