### PR TITLE
Fix: show sync start error

### DIFF
--- a/background/sync.js
+++ b/background/sync.js
@@ -192,6 +192,7 @@ const sync = (() => {
         .catch(handle401Error)
         .then(() => syncNow()),
       err => {
+        status.errorMessage = err ? err.message : null;
         // FIXME: should we move this logic to options.js?
         if (err && !fromPref) {
           console.error(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Stylus",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Correctly display sync start errors e.g. connecting to onedrive on latest Firefox:
![image](https://user-images.githubusercontent.com/1324510/90245265-eea35980-de64-11ea-995a-ad7258eb9023.png)
