### PR TITLE
use tab.pendingUrl

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -328,7 +328,7 @@ function openManage({options = false, search} = {}) {
       if (tab) {
         return Promise.all([
           activateTab(tab),
-          tab.url !== url && msg.sendTab(tab.id, {method: 'pushState', url})
+          (tab.pendingUrl || tab.url) !== url && msg.sendTab(tab.id, {method: 'pushState', url})
             .catch(console.error)
         ]);
       }

--- a/background/content-scripts.js
+++ b/background/content-scripts.js
@@ -58,13 +58,13 @@ const contentScripts = (() => {
     return browser.tabs.query({}).then(tabs => {
       for (const tab of tabs) {
         // skip unloaded/discarded/chrome tabs
-        if (!tab.width || tab.discarded || !URLS.supported(tab.url)) continue;
+        if (!tab.width || tab.discarded || !URLS.supported(tab.pendingUrl || tab.url)) continue;
         // our content scripts may still be pending injection at browser start so it's too early to ping them
         if (tab.status === 'loading') {
           trackBusyTab(tab.id, true);
         } else {
           injectToTab({
-            url: tab.url,
+            url: tab.pendingUrl || tab.url,
             tabId: tab.id
           });
         }

--- a/background/navigator-util.js
+++ b/background/navigator-util.js
@@ -49,8 +49,9 @@ const navigatorUtil = (() => {
     }
     return browser.tabs.get(data.tabId)
       .then(tab => {
-        if (tab.url === 'chrome://newtab/') {
-          data.url = tab.url;
+        const url = tab.pendingUrl || tab.url;
+        if (url === 'chrome://newtab/') {
+          data.url = url;
         }
       });
   }

--- a/edit/regexp-tester.js
+++ b/edit/regexp-tester.js
@@ -67,8 +67,7 @@ const regExpTester = (() => {
     });
     const getMatchInfo = m => m && {text: m[0], pos: m.index};
     browser.tabs.query({}).then(tabs => {
-      const supported = tabs.map(tab => tab.url)
-        .filter(url => URLS.supported(url));
+      const supported = tabs.map(tab => tab.pendingUrl || tab.url).filter(URLS.supported);
       const unique = [...new Set(supported).values()];
       for (const rxData of regexps) {
         const {rx, urls} = rxData;

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -132,7 +132,7 @@ function findExistingTab({url, currentWindow, ignoreHash = true, ignoreSearch = 
     .then(tabs => tabs.find(matchTab));
 
   function matchTab(tab) {
-    const tabUrl = new URL(tab.url);
+    const tabUrl = new URL(tab.pendingUrl || tab.url);
     return tabUrl.protocol === url.protocol &&
       tabUrl.username === url.username &&
       tabUrl.password === url.password &&
@@ -175,7 +175,7 @@ function openURL({
         index,
         openerTabId,
         // when hash is different we can only set `url` if it has # otherwise the tab would reload
-        url: url !== tab.url && url.includes('#') ? url : undefined,
+        url: url !== (tab.pendingUrl || tab.url) && url.includes('#') ? url : undefined,
       });
     }
     if (newWindow && browser.windows) {
@@ -200,10 +200,9 @@ function openURL({
 // except when new URL is chrome:// or chrome-extension:// and the empty tab is
 // in incognito
 function isTabReplaceable(tab, newUrl) {
-  if (!tab || !URLS.emptyTab.includes(tab.url)) {
+  if (!tab || !URLS.emptyTab.includes(tab.pendingUrl || tab.url)) {
     return false;
   }
-  // FIXME: but why?
   if (tab.incognito && newUrl.startsWith('chrome')) {
     return false;
   }

--- a/js/msg.js
+++ b/js/msg.js
@@ -106,12 +106,13 @@ self.msg = self.INJECTED === 1 ? self.msg : (() => {
       .then(tabs => {
         const requests = [];
         for (const tab of tabs) {
-          const isExtension = tab.url.startsWith(EXTENSION_URL);
+          const tabUrl = tab.pendingUrl || tab.url;
+          const isExtension = tabUrl.startsWith(EXTENSION_URL);
           if (
             tab.discarded ||
             // FIXME: use `URLS.supported`?
-            !/^(http|ftp|file)/.test(tab.url) &&
-            !tab.url.startsWith('chrome://newtab/') &&
+            !/^(http|ftp|file)/.test(tabUrl) &&
+            !tabUrl.startsWith('chrome://newtab/') &&
             !isExtension ||
             isExtension && ignoreExtension ||
             filter && !filter(tab)


### PR DESCRIPTION
Fixes #1039, arguably.

When a tab is pending navigation, the new URL is set only as [tab.pendingUrl](https://developer.chrome.com/extensions/tabs#type-Tab) since Chrome/ium 79, so we need to always check it prior to `tab.url` except when it doesn't make sense, like in FF, duh. Note that in new tabs pending navigation `tab.url` is empty `''`, which seems to be the cause of the linked bug.