### PR TITLE
parser: enable starHack option + new props

### DIFF
--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -105,6 +105,7 @@
   }
 
   Object.assign(CodeMirror.mimeModes['text/css'].propertyKeywords, {
+    'content-visibility': true,
     'overflow-anchor': true,
     'overscroll-behavior': true,
   });

--- a/js/moz-parser.js
+++ b/js/moz-parser.js
@@ -18,7 +18,7 @@ function parseMozFormat({code, styleId}) {
     'regexp':     'regexps',
   };
   const hasSingleEscapes = /([^\\]|^)\\([^\\]|$)/;
-  const parser = new parserlib.css.Parser();
+  const parser = new parserlib.css.Parser({starHack: true});
   const sectionStack = [{code: '', start: 0}];
   const errors = [];
   const sections = [];

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -286,6 +286,7 @@ self.parserlib = (() => {
     'columns':           1,
     'contain':           'none | strict | content | [ size || layout || style || paint ]',
     'content':           'normal | none | <content-list> [ / <string> ]?',
+    'content-visibility': 'visible | auto | hidden',
     'counter-increment': 1,
     'counter-reset':     1,
     'crop':              'rect() | inset-rect() | auto',


### PR DESCRIPTION
Turns out `*` in `*color: red` is a [IE hack](https://stackoverflow.com/a/1690683/) so it's used in the wild. Our linter already has starHack enabled and processes (ignores) `*` successfully. Now, this PR enables the same for the parser.

Fixes #1035.