### PR TITLE
rework and move newUI+theme to options.html

### DIFF
--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -217,10 +217,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Стилове за редактора",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Включване",
     "description": "Label for the button to enable a style"

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -305,10 +305,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Najít styly pro editor",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Povolit",
     "description": "Label for the button to enable a style"

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -309,10 +309,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Editor Styles finden",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Aktivieren",
     "description": "Label for the button to enable a style"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1009,7 +1009,7 @@
     "message": "Reset options"
   },
   "optionsStylusThemes": {
-    "message": "Find themes for Stylus itself on userstyles.org"
+    "message": "Find a Stylus UI theme"
   },
   "optionsSubheading": {
     "message": "More Options",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -319,10 +319,6 @@
     },
     "description": "Title of the page for editing styles"
   },
-  "editorStylesButton": {
-    "message": "Find editor styles",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Enable",
     "description": "Label for the button to enable a style"
@@ -1011,6 +1007,9 @@
   },
   "optionsResetButton": {
     "message": "Reset options"
+  },
+  "optionsStylusThemes": {
+    "message": "Find themes for Stylus itself on userstyles.org"
   },
   "optionsSubheading": {
     "message": "More Options",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -313,10 +313,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Buscar estilos del editor",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Activar",
     "description": "Label for the button to enable a style"

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -313,10 +313,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Leia redaktori stiile",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Luba",
     "description": "Label for the button to enable a style"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -321,10 +321,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Trouver des styles pour l’éditeur",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Activer",
     "description": "Label for the button to enable a style"

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -321,10 +321,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "מצא עיצובים לעורך",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "אפשר",
     "description": "Label for the button to enable a style"

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -309,10 +309,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "A szerkesztő stílusainak keresése",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Engedélyezés",
     "description": "Label for the button to enable a style"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -273,10 +273,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Cerca stili editor",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Attiva",
     "description": "Label for the button to enable a style"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -313,10 +313,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "エディタのスタイルを見つける",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "有効化",
     "description": "Label for the button to enable a style"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -317,10 +317,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "편집기 스타일 찾기",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "활성화",
     "description": "Label for the button to enable a style"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -317,10 +317,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Editorstijlen zoeken",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Inschakelen",
     "description": "Label for the button to enable a style"

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -321,10 +321,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Znajdź style edytora",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Włącz",
     "description": "Label for the button to enable a style"

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -301,10 +301,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Encontrar estilos para o editor",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Ativar",
     "description": "Label for the button to enable a style"

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -269,10 +269,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Găsiți teme pentru editor",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Activați",
     "description": "Label for the button to enable a style"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -321,10 +321,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Сменить тему Стилус",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Включить",
     "description": "Label for the button to enable a style"

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -309,10 +309,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Hitta redaktörsstilar",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Aktivera",
     "description": "Label for the button to enable a style"

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -309,10 +309,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "Editör stili bul",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "Etkinleştir",
     "description": "Label for the button to enable a style"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -321,10 +321,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "查找编辑器样式",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "启用",
     "description": "Label for the button to enable a style"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -321,10 +321,6 @@
       }
     }
   },
-  "editorStylesButton": {
-    "message": "找到編輯器樣式",
-    "description": "Find styles for the editor"
-  },
   "enableStyleLabel": {
     "message": "啟用",
     "description": "Label for the button to enable a style"

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -28,9 +28,9 @@ self.prefs = self.INJECTED === 1 ? self.prefs : (() => {
     'manage.onlyLocal.invert': false,   // display only externally installed styles
     'manage.onlyUsercss.invert': false, // display only non-usercss (standard) styles
     // UI element state: expanded/collapsed
+    'manage.actions.expanded': true,
     'manage.backup.expanded': true,
     'manage.filters.expanded': true,
-    'manage.options.expanded': true,
     // the new compact layout doesn't look good on Android yet
     'manage.newUI': !navigator.appVersion.includes('Android'),
     'manage.newUI.favicons': false, // show favicons for the sites in applies-to

--- a/manage.html
+++ b/manage.html
@@ -278,8 +278,11 @@
           <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
         </a>
       </div>
+    </div>
 
-      <div id="style-actions">
+    <div class="settings-column">
+      <details id="actions" data-pref="manage.actions.expanded">
+        <summary><h2 i18n-text="optionsActions"></h2></summary>
         <div id="update-check">
           <button id="check-all-updates" i18n-text="checkAllUpdates"><span id="update-progress"></span></button>
           <a href="#" id="update-history" i18n-title="genericHistoryLabel" tabindex="0">
@@ -313,57 +316,12 @@
             </a>
           </label>
         </div>
-      </div>
+
+        <button id="manage-options-button" i18n-text="openOptions"></button>
+      </details>
     </div>
 
     <div class="settings-column">
-      <details id="options" data-pref="manage.options.expanded">
-
-        <summary><h2 id="options-heading" i18n-text="optionsHeading"></h2></summary>
-
-        <label>
-          <input id="manage.newUI" type="checkbox">
-          <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
-          <span i18n-text="manageNewUI"></span>
-        </label>
-
-        <div id="newUIoptions">
-          <div>
-            <label for="manage.newUI.favicons" i18n-text="manageFavicons">
-              <input id="manage.newUI.favicons" type="checkbox">
-              <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
-              <a href="#" data-toggle-on-click="#faviconsHelp" tabindex="0">
-                <svg class="svg-icon select-arrow">
-                  <title i18n-text="optionsSubheading"></title>
-                  <use xlink:href="#svg-icon-select-arrow"/>
-                </svg>
-              </a>
-            </label>
-            <div id="faviconsHelp" class="hidden" i18n-text="manageFaviconsHelp">
-              <div>
-                <label for="manage.newUI.faviconsGray" i18n-text="manageFaviconsGray">
-                  <input id="manage.newUI.faviconsGray" type="checkbox">
-                  <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
-                </label>
-              </div>
-            </div>
-          </div>
-         <label><input id="manage.newUI.targets" type="number" min="1" max="99"><span i18n-text="manageMaxTargets"></span></label>
-        </div>
-
-        <div id="options-buttons">
-          <button id="manage-options-button" i18n-text="openOptions"></button>
-          <button id="manage-shortcuts-button" class="chromium-only"
-                  i18n-text="shortcuts"
-                  i18n-title="shortcutsNote"></button>
-          <a id="find-editor-styles"
-             href="https://userstyles.org/styles/browse/chrome-extension"
-             i18n-title="editorStylesButton"
-             target="_blank"><button i18n-text="cm_theme" tabindex="-1"></button></a>
-        </div>
-
-      </details>
-
       <details id="backup" data-pref="manage.backup.expanded">
         <summary><h2 id="backup-title" i18n-text="backupButtons"></h2></summary>
         <span id="backup-message" i18n-text="backupMessage"></span>

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -285,14 +285,6 @@ a:hover {
   margin-top: .5rem;
 }
 
-#options-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  padding-top: .1rem;
-}
-
-#options-buttons > a,
-#options-buttons > button,
 #backup-buttons button {
   margin: 0 .2rem .5rem 0;
 }
@@ -695,65 +687,6 @@ a:hover {
   filter: grayscale(0);
 }
 
-#newUIoptions {
-  display: none;
-}
-
-.newUI #newUIoptions {
-  display: initial;
-}
-
-#newUIoptions > * {
-  display: flex;
-  align-items: center;
-  margin-bottom: auto;
-  flex-wrap: wrap;
-  position: relative;
-}
-
-#newUIoptions input[type="number"] {
-  width: 3em;
-  margin-right: .5em;
-}
-
-#newUIoptions [data-toggle-on-click="#faviconsHelp"] {
-  width: 14px;
-  height: 14px;
-  display: inline-block;
-  vertical-align: middle;
-  position: relative;
-  top: -1px;
-}
-
-#newUIoptions [data-toggle-on-click] > svg {
-  position:  static;
-}
-
-#newUIoptions [data-toggle-on-click]:not([open]) > svg {
-  /* note: without ">" FF52 also transforms the nested svg inside <use> */
-  transform: rotate(-90deg);
-}
-
-html:not(.newUI) #newUIoptions + * {
-  margin-top: .5em;
-}
-
-input[id^="manage.newUI"] {
-  margin-left: 0;
-}
-
-#faviconsHelp {
-  overflow-y: auto;
-  font-size: 90%;
-  padding: 1ex 0 2ex 16px;
-}
-
-#faviconsHelp div {
-  display: flex;
-  align-items: center;
-  margin-top: 1ex;
-}
-
 /* Default, no update buttons */
 .updater-icons .update,
 .updater-icons .check-update {
@@ -1076,6 +1009,10 @@ input[id^="manage.newUI"] {
 
 #stylus-embedded-options.fadeout {
   animation: fadeout .25s ease-in-out;
+}
+
+.settings-column {
+  margin-top: 1rem;
 }
 
 @keyframes fadein {

--- a/options.html
+++ b/options.html
@@ -45,8 +45,8 @@
       <h1 i18n-text="cm_theme"></h1>
       <div class="items">
         <label>
-          <a i18n-text="editorStylesButton" target="_blank"
-             href="https://userstyles.org/styles/browse/chrome-extension"> - userstyles.org</a>
+          <a i18n-text="optionsStylusThemes" target="_blank"
+             href='https://userstyles.org/styles/browse/chrome-extension'></a>
         </label>
       </div>
     </div>

--- a/options.html
+++ b/options.html
@@ -46,7 +46,7 @@
       <div class="items">
         <label>
           <a i18n-text="optionsStylusThemes" target="_blank"
-             href="https://33kk.github.io/uso-archive/?category=chrome-extension&sort=recently-updated"></a>
+             href="https://33kk.github.io/uso-archive/?category=chrome-extension&sort=recently-updated&search=Stylus"></a>
         </label>
       </div>
     </div>

--- a/options.html
+++ b/options.html
@@ -42,6 +42,16 @@
   <div id="options">
 
     <div class="block">
+      <h1 i18n-text="cm_theme"></h1>
+      <div class="items">
+        <label>
+          <a i18n-text="editorStylesButton" target="_blank"
+             href="https://userstyles.org/styles/browse/chrome-extension"> - userstyles.org</a>
+        </label>
+      </div>
+    </div>
+
+    <div class="block">
       <h1 i18n-text="optionsCustomizeIcon"></h1>
       <div class="items">
         <label>
@@ -121,6 +131,45 @@
             <input type="checkbox" id="popup.borders" class="slider">
             <span></span>
           </span>
+        </label>
+      </div>
+    </div>
+
+    <div class="block">
+      <h1 i18n-text="openManage"></h1>
+      <div class="items">
+        <label>
+          <span i18n-text="manageNewUI"></span>
+          <span class="onoffswitch">
+            <input type="checkbox" id="manage.newUI" class="slider">
+            <span></span>
+          </span>
+        </label>
+        <label>
+          <span i18n-text="manageFavicons">
+            <a data-cmd="note"
+               i18n-title="manageFaviconsHelp"
+               href="#"
+               class="svg-inline-wrapper"
+               tabindex="0">
+              <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
+            </a>
+          </span>
+          <span class="onoffswitch">
+            <input type="checkbox" id="manage.newUI.favicons" class="slider">
+            <span></span>
+          </span>
+        </label>
+        <label>
+          <span i18n-text="manageFaviconsGray"></span>
+          <span class="onoffswitch">
+            <input type="checkbox" id="manage.newUI.faviconsGray" class="slider">
+            <span></span>
+          </span>
+        </label>
+        <label>
+          <span i18n-text="manageMaxTargets"></span>
+          <input id="manage.newUI.targets" type="number" min="1" max="99">
         </label>
       </div>
     </div>

--- a/options.html
+++ b/options.html
@@ -46,7 +46,7 @@
       <div class="items">
         <label>
           <a i18n-text="optionsStylusThemes" target="_blank"
-             href="https://33kk.github.io/uso-archive/?category=chrome-extension&sort=recently-updated&search=Stylus"></a>
+             href="https://33kk.github.io/uso-archive/?category=chrome-extension&search=Stylus"></a>
         </label>
       </div>
     </div>

--- a/options.html
+++ b/options.html
@@ -46,7 +46,7 @@
       <div class="items">
         <label>
           <a i18n-text="optionsStylusThemes" target="_blank"
-             href='https://userstyles.org/styles/browse/chrome-extension'></a>
+             href="https://33kk.github.io/uso-archive/?category=chrome-extension&sort=recently-updated"></a>
         </label>
       </div>
     </div>

--- a/options/options.js
+++ b/options/options.js
@@ -6,7 +6,7 @@
 
 setupLivePrefs();
 setupRadioButtons();
-enforceInputRange($('#popupWidth'));
+$$('input[min], input[max]').forEach(enforceInputRange);
 setTimeout(splitLongTooltips);
 
 // https://github.com/openstyles/stylus/issues/822


### PR DESCRIPTION
Moves the 1) newUI options block and 2) theme button from the manager into the options page which we/I wanted to do since forever once we made a dedicated options page. The shortcuts button is already present in the options page.

Now that the theme option is in the options page, it should increase its discoverability which was kinda low due to the dense and cluttered nav panel in manage.html.