### PR TITLE
expose version for styles installed from greasyfork/sleazyfork

### DIFF
--- a/background/content-scripts.js
+++ b/background/content-scripts.js
@@ -17,6 +17,21 @@ const contentScripts = (() => {
   }
   const busyTabs = new Set();
   let busyTabsTimer;
+
+  // expose version on greasyfork/sleazyfork 1) info page and 2) code page
+  const urlMatches = '/scripts/\\d+[^/]*(/code)?([?#].*)?$';
+  chrome.webNavigation.onCommitted.addListener(({tabId}) => {
+    chrome.tabs.executeScript(tabId, {
+      file: '/content/install-hook-greasyfork.js',
+      runAt: 'document_start',
+    });
+  }, {
+    url: [
+      {hostEquals: 'greasyfork.org', urlMatches},
+      {hostEquals: 'sleazyfork.org', urlMatches},
+    ]
+  });
+
   return {injectToTab, injectToAllTabs};
 
   function injectToTab({url, tabId, frameId = null}) {

--- a/content/install-hook-greasyfork.js
+++ b/content/install-hook-greasyfork.js
@@ -1,0 +1,21 @@
+/* global API */
+'use strict';
+
+// onCommitted may fire twice
+// Note, we're checking against a literal `1`, not just `if (truthy)`,
+// because <html id="INJECTED"> is exposed per HTML spec as a global variable and `window.INJECTED`.
+
+if (window.INJECTED_GREASYFORK !== 1) {
+  window.INJECTED_GREASYFORK = 1;
+  addEventListener('message', async function onMessage(e) {
+    if (e.origin === location.origin &&
+        e.data &&
+        e.data.name &&
+        e.data.type === 'style-version-query') {
+      removeEventListener('message', onMessage);
+      const style = await API.findUsercss(e.data) || {};
+      const {version} = style.usercssData || {};
+      postMessage({type: 'style-version', version}, '*');
+    }
+  });
+}


### PR DESCRIPTION
Fixes #842.

Uses messaging via `window`.

The content script is injected dynamically because AFAIK browsers still retardedly disable the extension on update when a content script is added in manifest.json even though it does not actually extend the previous span of host access, which is already `<all_urls>`.