### PR TITLE
treat empty url-prefix() as non-matching

### DIFF
--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -586,7 +586,7 @@ const styleManager = (() => {
     ) {
       return true;
     }
-    if (section.urlPrefixes && section.urlPrefixes.some(p => query.url.startsWith(p))) {
+    if (section.urlPrefixes && section.urlPrefixes.some(p => p && query.url.startsWith(p))) {
       return true;
     }
     // as per spec the fragment portion is ignored in @-moz-document:


### PR DESCRIPTION
Fixes #735.

Sections with an empty `url-prefix` won't become global now.

Quoting myself:

> Theoretically it might break a couple of styles where clueless authors added a useless `@-moz-document url-prefix("")` but I think we can ignore that as it's totally nonsensical. If someone wanted to "organize" the code that way they could simply use `@-moz-document { ............ }` without `url-prefix`.