### PR TITLE
ignore empty documents produced by stylus-lang bug

### DIFF
--- a/background/background-worker.js
+++ b/background/background-worker.js
@@ -39,7 +39,7 @@ function compileUsercss(preprocessor, code, vars) {
   const builder = getUsercssCompiler(preprocessor);
   vars = simpleVars(vars);
   return Promise.resolve(builder.preprocess ? builder.preprocess(code, vars) : code)
-    .then(code => parseMozFormat({code}))
+    .then(code => parseMozFormat({code, emptyDocument: preprocessor === 'stylus'}))
     .then(({sections, errors}) => {
       if (builder.postprocess) {
         builder.postprocess(sections, vars);

--- a/js/usercss.js
+++ b/js/usercss.js
@@ -71,7 +71,7 @@ const usercss = (() => {
       .then(({sections, errors}) => {
         if (!errors.length) errors = false;
         if (!sections.length || errors && !allowErrors) {
-          throw errors;
+          throw errors || 'Style does not contain any actual CSS to apply.';
         }
         style.sections = sections;
         return allowErrors ? {style, errors} : style;

--- a/vendor-overwrites/csslint/parserlib.js
+++ b/vendor-overwrites/csslint/parserlib.js
@@ -3856,6 +3856,7 @@ self.parserlib = (() => {
      * @param {Boolean} [options.starHack] - allows IE6 star hack
      * @param {Boolean} [options.underscoreHack] - interprets leading underscores as IE6-7 for known properties
      * @param {Boolean} [options.ieFilters] - accepts IE < 8 filters instead of throwing syntax errors
+     * @param {Boolean} [options.emptyDocument] - accepts @document without {} block produced by stylus-lang
      */
     constructor(options) {
       super();
@@ -4329,6 +4330,11 @@ self.parserlib = (() => {
         functions.push(this._documentFunction());
       } while (stream.match(Tokens.COMMA));
 
+      this._ws();
+      if (this.options.emptyDocument && stream.peek() !== Tokens.LBRACE) {
+        this.fire({type: 'emptydocument', functions, prefix}, start);
+        return;
+      }
       stream.mustMatch(Tokens.LBRACE);
 
       this.fire({


### PR DESCRIPTION
fixes #477 since we still couldn't find a way to build the updated stylus-lang into a small bundle ourselves.