### PR TITLE
use adoptedStyleSheets

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -943,6 +943,9 @@
   "optionsAdvanced": {
     "message": "Advanced"
   },
+  "optionsAdvancedAdoptedStyleSheets": {
+    "message": "Apply styles directly via <a href='https://developers.google.com/web/updates/2019/02/constructable-stylesheets'>AdoptedStyleSheets</a>"
+  },
   "optionsAdvancedContextDelete": {
     "message": "Add 'Delete' in editor context menu"
   },

--- a/content/apply.js
+++ b/content/apply.js
@@ -59,7 +59,7 @@ self.INJECTED !== 1 && (() => {
   function init() {
     return STYLE_VIA_API ?
       API.styleViaAPI({method: 'styleApply'}) :
-      API.getSectionsByUrl(getMatchUrl()).then(styleInjector.apply);
+      API.getSectionsByUrl(getMatchUrl(), null, true).then(styleInjector.apply);
   }
 
   function getMatchUrl() {

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -9,6 +9,7 @@ self.prefs = self.INJECTED === 1 ? self.prefs : (() => {
     'disableAll': false,            // boss key
     'exposeIframes': false,         // Add 'stylus-iframe' attribute to HTML element in all iframes
     'newStyleAsUsercss': false,     // create new style in usercss format
+    'adoptedStyleSheets': false,    // try to apply styles via document.adoptedStyleSheets
 
     // checkbox in style config dialog
     'config.autosave': true,

--- a/options.html
+++ b/options.html
@@ -233,6 +233,13 @@
       </div>
       <div class="items">
         <label>
+          <span i18n-html="optionsAdvancedAdoptedStyleSheets"></span>
+          <span class="onoffswitch">
+            <input type="checkbox" id="adoptedStyleSheets" class="slider">
+            <span></span>
+          </span>
+        </label>
+        <label>
           <span i18n-text="optionsAdvancedExposeIframes">
             <a data-cmd="note"
                i18n-title="optionsAdvancedExposeIframesNote"

--- a/options/options.js
+++ b/options/options.js
@@ -38,6 +38,10 @@ if (FIREFOX && 'update' in (chrome.commands || {})) {
   });
 }
 
+if (!Array.isArray(document.adoptedStyleSheets)) {
+  $('#adoptedStyleSheets').closest('label').classList.add('hidden');
+}
+
 // actions
 $('#options-close-icon').onclick = () => {
   top.dispatchEvent(new CustomEvent('closeOptions'));


### PR DESCRIPTION
Fixes #1033.

Switches to document.adoptedStyleSheets to apply styles.

Disabled by default, the option is "Apply styles directly via [AdoptedStyleSheets](https://developers.google.com/web/updates/2019/02/constructable-stylesheets)"

Performance-wise it seems the same. Not sure if we should merge this PR because while it solves the linked issue, a) it theoretically may have problems when sites start to use ASS in the future, b) styles with `@import` aren't supported so they will be created as `<style>` elements that go in their own classic document.styleSheets so it obviously won't have the correct position as we will have our styles split between the two lists, c) this PR doesn't implement the killer feature of the new API: the ability to style ShadowDOM.

So this is more of a PoC. For a long-term solution of #1033 as well as all CSP-related bugs in Firefox we should use insertCSS + removeCSS (the latter is already implemented in the upcoming Chrome) and if it's as fast as the classic approach then we could just use it everywhere in the new browsers, otherwise provide an option to specify sites where it's used.