### PR TITLE
option to open editor in a simple window (no omnibox)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1122,6 +1122,10 @@
     "message": "Action menu",
     "description": "Tooltip for menu button in popup."
   },
+  "popupOpenEditInPopup": {
+    "message": "Use a simple window (no omnibox)",
+    "description": "Label for the checkbox controlling 'edit' action behavior in the popup."
+  },
   "popupOpenEditInWindow": {
     "message": "Open editor in a new window",
     "description": "Label for the checkbox controlling 'edit' action behavior in the popup."

--- a/background/background.js
+++ b/background/background.js
@@ -303,9 +303,10 @@ function openEditor(params) {
   u.search = new URLSearchParams(params);
   return openURL({
     url: `${u}`,
-    newWindow: prefs.get('openEditInWindow'),
-    windowPosition: prefs.get('windowPosition'),
-    currentWindow: null
+    currentWindow: null,
+    newWindow: prefs.get('openEditInWindow') && Object.assign({},
+      prefs.get('openEditInWindow.popup') && {type: 'popup'},
+      prefs.get('windowPosition')),
   });
 }
 

--- a/js/messaging.js
+++ b/js/messaging.js
@@ -191,8 +191,8 @@ async function openURL({
   if (newWindow && browser.windows) {
     return (await browser.windows.create(Object.assign({url}, newWindow)).tabs)[0];
   }
-  tab = await getActiveTab();
-  if (await isTabReplaceable(tab, url)) {
+  tab = await getActiveTab() || {url: ''};
+  if (isTabReplaceable(tab, url)) {
     return activateTab(tab, {url, openerTabId});
   }
   const id = openerTabId == null ? tab.id : openerTabId;

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -4,6 +4,7 @@
 self.prefs = self.INJECTED === 1 ? self.prefs : (() => {
   const defaults = {
     'openEditInWindow': false,      // new editor opens in a own browser window
+    'openEditInWindow.popup': false, // new editor opens in a simplified browser window without omnibox
     'windowPosition': {},           // detached window position
     'show-badge': true,             // display text on popup menu icon
     'disableAll': false,            // boss key

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -392,10 +392,11 @@ Object.assign(handleEvent, {
     const openWindow = left && shift && !ctrl;
     const openBackgroundTab = (middle && !shift) || (left && ctrl && !shift);
     const openForegroundTab = (middle && shift) || (left && ctrl && shift);
-    const url = $('[href]', event.target.closest('.entry')).href;
+    const entry = event.target.closest('.entry');
+    const url = $('[href]', entry).href;
     if (openWindow || openBackgroundTab || openForegroundTab) {
       if (chrome.windows && openWindow) {
-        chrome.windows.create(Object.assign(prefs.get('windowPosition'), {url}));
+        API.openEditor({id: entry.styleId});
       } else {
         getOwnTab().then(({index}) => {
           openURL({

--- a/options.html
+++ b/options.html
@@ -112,6 +112,13 @@
           </span>
         </label>
         <label>
+          <span i18n-text="popupOpenEditInPopup"></span>
+          <span class="onoffswitch">
+            <input type="checkbox" id="openEditInWindow.popup" class="slider">
+            <span></span>
+          </span>
+        </label>
+        <label>
           <span i18n-text="popupStylesFirst"></span>
           <span class="onoffswitch">
             <input type="checkbox" id="popup.stylesFirst" class="slider">


### PR DESCRIPTION
Adds an option to use a simple window (no omnibox) when opening editor in a new window.

The option is not enabled by default in order not to aggravate the users. FWIW personally I like this simplified window better as there are no distractions and it provides more space for the code.