### PR TITLE
async'ify msg, don't throw for flow control

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -258,7 +258,7 @@ if (FIREFOX && browser.commands && browser.commands.update) {
   });
 }
 
-msg.broadcastTab({method: 'backgroundReady'});
+msg.broadcast({method: 'backgroundReady'});
 
 function webNavIframeHelperFF({tabId, frameId}) {
   if (!frameId) return;

--- a/content/apply.js
+++ b/content/apply.js
@@ -150,13 +150,10 @@ self.INJECTED !== 1 && (() => {
         break;
 
       case 'backgroundReady':
-        initializing
-          .catch(err => {
-            if (msg.RX_NO_RECEIVER.test(err.message)) {
-              return init();
-            }
-          })
-          .catch(console.error);
+        initializing.catch(err =>
+          msg.isIgnorableError(err)
+            ? init()
+            : console.error(err));
         break;
 
       case 'updateCount':

--- a/js/msg.js
+++ b/js/msg.js
@@ -40,8 +40,7 @@ window.INJECTED !== 1 && (() => {
           tab: NEEDS_TAB_IN_SENDER.includes(name) && await getOwnTab(),
           url: location.href,
         });
-        // avoiding an unnecessary `await` microtask сycle
-        return deepCopy(res instanceof bg.Promise ? await res : res);
+        return deepCopy(await res);
       };
     },
   });


### PR DESCRIPTION
Fixes #906.

There should be no functional changes but let's test this for a while anyway.

Code-wise, since conversion to async/await changes the code a lot, I also shuffled and reworked the entire msg.js mainly to reduce indirection i.e. to make call chains shorter hence more obvious while debugging or navigating through the code especially when using "jump to definition" and "peek definition".