### PR TITLE
tweak colorpicker

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -182,6 +182,9 @@
     "message": "Theme",
     "description": "Label for the style editor's CSS theme."
   },
+  "colorpickerPaletteHint": {
+    "message": "Right-click a swatch to cycle through its source lines"
+  },
   "colorpickerSwitchFormatTooltip": {
     "message": "Switch formats: HEX -> RGB -> HSL.\nShift-click to reverse the direction.\nAlso via PgUp (PageUp), PgDn (PageDown) keys.",
     "description": "Tooltip for the switch button in the color picker popup in the style editor."
@@ -937,6 +940,10 @@
   "noStylesForSite": {
     "message": "No styles installed for this site.",
     "description": "Text displayed when no styles are installed for the current site"
+  },
+  "numberedLine": {
+    "message": "Line:",
+    "description": "Will be followed by one or more line numbers in the editor."
   },
   "openManage": {
     "message": "Manage",

--- a/edit/colorpicker-helper.js
+++ b/edit/colorpicker-helper.js
@@ -23,12 +23,19 @@
         tooltip: t('colorpickerTooltip'),
         popup: {
           tooltipForSwitcher: t('colorpickerSwitchFormatTooltip'),
+          paletteLine: t('numberedLine'),
+          paletteHint: t('colorpickerPaletteHint'),
           hexUppercase: prefs.get('editor.colorpicker.hexUppercase'),
-          hideDelay: 30e3,
           embedderCallback: state => {
             ['hexUppercase', 'color']
               .filter(name => state[name] !== prefs.get('editor.colorpicker.' + name))
               .forEach(name => prefs.set('editor.colorpicker.' + name, state[name]));
+          },
+          get maxHeight() {
+            return prefs.get('editor.colorpicker.maxHeight');
+          },
+          set maxHeight(h) {
+            prefs.set('editor.colorpicker.maxHeight', h);
           },
         },
       };

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -86,6 +86,7 @@ self.prefs = self.INJECTED === 1 ? self.prefs : (() => {
     'editor.colorpicker.hotkey': '',
     // last color
     'editor.colorpicker.color': '',
+    'editor.colorpicker.maxHeight': 300,
 
     // Firefox-only chrome.commands.update
     'hotkey._execute_browser_action': '',

--- a/manage/config-dialog.js
+++ b/manage/config-dialog.js
@@ -399,7 +399,6 @@ function configDialog(style) {
       color: this.va.value || this.va.default,
       top: this.getBoundingClientRect().bottom - 5,
       left: box.getBoundingClientRect().left - 360,
-      hideDelay: 1e6,
       guessBrightness: box,
       callback: onColorChanged,
     });

--- a/vendor-overwrites/colorpicker/colorpicker.css
+++ b/vendor-overwrites/colorpicker/colorpicker.css
@@ -77,9 +77,13 @@
 }
 
 .colorpicker-popup {
-  --switcher-width: 30px;
-  position: relative;
+  --switcher-width: 29px;
+  --sat-height: 120px;
+  position: fixed;
+  display: flex;
+  flex-direction: column;
   width: 325px;
+  max-height: var(--fit-height);
   z-index: 1000;
   transition: opacity .5s;
   color: var(--label-color);
@@ -90,17 +94,42 @@
   user-select: none;
 }
 
-.colorpicker-popup[data-fading="1"] {
-  opacity: .75;
+.colorpicker-popup[data-moving] {
+  opacity: .5;
+  cursor: move;
 }
 
-.colorpicker-popup[data-fading="2"] {
-  opacity: 0;
+.colorpicker-popup[data-resizing] {
+  max-height: 90vh !important;
+}
+
+.colorpicker-popup[data-resizable] {
+  resize: vertical;
+  overflow: hidden;
+}
+
+.colorpicker-popup-mover {
+  position: absolute;
+  box-sizing: border-box;
+  width: calc(var(--switcher-width) - 10px);
+  height: 50px;
+  padding: 5px;
+  margin-top: 5px;
+  top: var(--sat-height);
+  right: 3px;
+  background: repeating-linear-gradient(to right,
+    currentColor, currentColor 1px, transparent 1px, transparent 3px);
+  cursor: move;
+  -webkit-background-clip: content-box;
+  background-clip: content-box;
+  opacity: .5;
+  z-index: 2;
 }
 
 .colorpicker-saturation-container {
   position: relative;
-  height: 120px;
+  height: var(--sat-height);
+  flex: 0 0 var(--sat-height);
   overflow: hidden;
   cursor: pointer;
 }
@@ -145,7 +174,7 @@
 
 .colorpicker-sliders {
   position: relative;
-  padding: 10px 0 6px 0;
+  padding: 10px calc(var(--switcher-width) - 12px) 6px 0;
   border-top: 1px solid transparent;
 }
 
@@ -156,10 +185,10 @@
 .colorpicker-swatch,
 .colorpicker-empty {
   position: absolute;
-  left: 11px;
-  top: 17px;
-  width: 30px;
-  height: 30px;
+  left: 10px;
+  top: 12px;
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
   box-sizing: border-box;
   border: 1px solid var(--input-border-color);
@@ -349,13 +378,24 @@
 }
 
 .colorpicker-palette:not(:empty) {
-  padding: 0 8px 8px;
-  min-height: 14px; /* same as padding-left in .colorview-swatch */
-  max-height: 10vw;
-  overflow: auto;
+  --swatch-size: 16px;
+  margin: 0 var(--margin) var(--margin);
+  min-height: calc(var(--swatch-size) - 4px);
+  overflow-y: auto;
   box-sizing: content-box;
 }
 
 .colorpicker-palette .colorview-swatch {
-  padding-bottom: 14px; /* same as padding-left in .colorview-swatch */
+  padding: calc(var(--swatch-size) / 2 + 1px);
+}
+
+.colorpicker-palette .colorview-swatch::before {
+  width: var(--swatch-size);
+  height: var(--swatch-size);
+}
+
+.colorpicker-palette-hint {
+  vertical-align: super;
+  padding: 0 .5em;
+  font-weight: bold;
 }


### PR DESCRIPTION
Fixes #1071.

Turns out the autohide feature was a legacy of the original code. No other apps have it AFAIK and it's pretty annoying to keep the mouse over the dialog to prevent it from closing so I've removed the option.

Increased the size of the big swatch on the left to make its margins more even. Kind of.

Added a grip area on the right to move the dialog. I'm not a UI designer but it's probably recognizable, moreover the cursor is changing which should make the function pretty much self-explanatory.

![image](https://user-images.githubusercontent.com/1310400/97041048-903adb80-1577-11eb-940d-5c823ad2fc3b.png)
