### PR TITLE
warn when paste-importing usercss with @preprocessor

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -468,6 +468,12 @@
     "message": "Import",
     "description": "Label for the button to import a style ('edit' page) or all styles ('manage' page)"
   },
+  "importPreprocessor": {
+    "message": "Style with a <code>@preprocessor</code> won't work in the classic mode. You can switch the editor to Usercss mode: 1) open the style manager, 2) enable \"as Usercss\" checkbox, 3) click \"Write new style\"\n\nImport now anyway?"
+  },
+  "importPreprocessorTitle": {
+    "message": "Potential problem due to @preprocessor"
+  },
   "importReplaceLabel": {
     "message": "Overwrite style",
     "description": "Label for the button to import and overwrite current style"

--- a/background/usercss-helper.js
+++ b/background/usercss-helper.js
@@ -8,6 +8,7 @@ const usercssHelper = (() => {
   API_METHODS.configUsercssVars = configUsercssVars;
 
   API_METHODS.buildUsercss = build;
+  API_METHODS.buildUsercssMeta = buildMeta;
   API_METHODS.findUsercss = find;
 
   function buildMeta(style) {

--- a/edit/sections-editor-section.js
+++ b/edit/sections-editor-section.js
@@ -176,10 +176,9 @@ function createSection({
     });
     cm.on('paste', (cm, event) => {
       const text = event.clipboardData.getData('text') || '';
-      if (
-        text.includes('@-moz-document') &&
-        text.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, '')
-          .match(/@-moz-document[\s\r\n]+(url|url-prefix|domain|regexp)\(/)
+      if (/@-moz-document/i.test(text) &&
+          /@-moz-document\s+(url|url-prefix|domain|regexp)\(/i
+            .test(text.replace(/\/\*([^*]|\*(?!\/))*(\*\/|$)/g, ''))
       ) {
         event.preventDefault();
         showMozillaFormatImport(text);

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -591,27 +591,21 @@ function createSectionsEditor(editorBase) {
     updateSectionOrder();
   }
 
-  function replaceStyle(newStyle, codeIsUpdated) {
+  async function replaceStyle(newStyle, codeIsUpdated) {
     dirty.clear('name');
     // FIXME: avoid recreating all editors?
-    reinit().then(() => {
-      Object.assign(style, newStyle);
-      updateHeader();
-      dirty.clear();
-      // Go from new style URL to edit style URL
-      if (location.href.indexOf('id=') === -1 && style.id) {
-        history.replaceState({}, document.title, 'edit.html?id=' + style.id);
-        $('#heading').textContent = t('editStyleHeading');
-      }
-      livePreview.show(Boolean(style.id));
-      updateLivePreview();
-    });
-
-    function reinit() {
-      if (codeIsUpdated !== false) {
-        return initSections(newStyle.sections, {replace: true, pristine: true});
-      }
-      return Promise.resolve();
+    if (codeIsUpdated !== false) {
+      await initSections(newStyle.sections, {replace: true, pristine: true});
     }
+    Object.assign(style, newStyle);
+    updateHeader();
+    dirty.clear();
+      // Go from new style URL to edit style URL
+    if (location.href.indexOf('id=') === -1 && style.id) {
+      history.replaceState({}, document.title, 'edit.html?id=' + style.id);
+      $('#heading').textContent = t('editStyleHeading');
+    }
+    livePreview.show(Boolean(style.id));
+    updateLivePreview();
   }
 }

--- a/msgbox/msgbox.css
+++ b/msgbox/msgbox.css
@@ -56,6 +56,10 @@
   text-align: left;
 }
 
+#message-box.pre-line #message-box-contents {
+  white-space: pre-line;
+}
+
 #message-box-title {
   font-weight: bold;
   background-color: rgb(145, 208, 198);

--- a/msgbox/msgbox.js
+++ b/msgbox/msgbox.js
@@ -168,10 +168,12 @@ messageBox.alert = (contents, className, title) =>
 /**
  * @param {String|Node|Array<String|Node>} contents
  * @param {String} [className] like 'pre' for monospace font
+ * @param {String} [title]
  * @returns {Promise<Boolean>} resolves to true when confirmed
  */
-messageBox.confirm = (contents, className) =>
+messageBox.confirm = (contents, className, title) =>
   messageBox({
+    title,
     contents,
     className: `center ${className || ''}`,
     buttons: [t('confirmYes'), t('confirmNo')]


### PR DESCRIPTION
Fixes #1080 by showing a warning when a non-empty `@preprocessor` is detected inside a valid usercss metadata comment. Didn't implement automatic switching to usercss mode because it's not trivial and this scenario is too rare to invest the effort.

![image](https://user-images.githubusercontent.com/1310400/97117155-f60f9a80-1712-11eb-8263-740c47870f4c.png)
