### PR TITLE
Simplify CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,12 @@ on: [push, pull_request]
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        node: ['10', '12', '14']
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '14'
       - run: npm install
       - run: npm test


### PR DESCRIPTION
Only run on a single node version, that way you won't get triple error annotations, and it's really not neccessary for this repo to test on multiples anyways.