### PR TITLE
save/restore section heights

### DIFF
--- a/background/update.js
+++ b/background/update.js
@@ -203,7 +203,10 @@
 
       json.id = style.id;
       json.updateDate = Date.now();
-
+      json.sections.forEach((sec, i) => {
+        const ls = (style.sections[i] || {}).localState;
+        if (ls) sec.localState = ls;
+      });
       // keep current state
       delete json.enabled;
 

--- a/edit/sections-editor-section.js
+++ b/edit/sections-editor-section.js
@@ -24,8 +24,9 @@ function createSection(originalSection, genId) {
   const el = template.section.cloneNode(true);
   const elLabel = $('.code-label', el);
   const cm = cmFactory.create(wrapper => {
+    const {height} = originalSection.localState || {};
     // making it tall during initial load so IntersectionObserver sees only one adjacent CM
-    wrapper.style.height = '100vh';
+    wrapper.style.height = height ? height + 'px' : '100vh';
     elLabel.after(wrapper);
   }, {
     value: originalSection.code,
@@ -57,7 +58,12 @@ function createSection(originalSection, genId) {
     appliesTo,
     getModel() {
       const items = appliesTo.map(a => !a.all && [a.type, a.value]);
-      return DocFuncMapper.toSection(items, {code: cm.getValue()});
+      const height = Number(cm.display.wrapper.style.height.match(/[0-9.]+(?=px)|$/)[0]) || 0;
+      return DocFuncMapper.toSection(items, Object.assign({
+        code: cm.getValue(),
+      }, height && {
+        localState: {height},
+      }));
     },
     remove() {
       linter.disableForEditor(cm);

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -171,8 +171,10 @@ function SectionsEditor() {
     const lastSectionBottom = sections[sections.length - 1].el.getBoundingClientRect().bottom;
     const delta = Math.floor((window.innerHeight - lastSectionBottom) / sections.length);
     if (delta > 1) {
-      sections.forEach(({cm}) => {
-        cm.setSize(null, cm.display.lastWrapHeight + delta);
+      sections.forEach(({cm}, i) => {
+        if (!(style.sections[i].localState || {}).height) {
+          cm.setSize(null, cm.display.wrapper.offsetHeight + delta);
+        }
       });
     }
   }
@@ -575,8 +577,9 @@ function SectionsEditor() {
     container.insertBefore(section.el, base ? base.el.nextSibling : null);
     refreshOnView(cm, forceRefresh);
     registerEvents(section);
-    if (!base || init.code) {
-      // Fit a) during startup or b) when the clone button is clicked on a section with some code
+    /* Fit a) when the clone button is clicked on a section with non-empty code
+       or b) during startup if height wasn't saved in storage */
+    if (base ? init.code : !(init.localState || {}).height) {
       fitToContent(section);
     }
     if (base) {


### PR DESCRIPTION
Fixes #1084.

This is a simpler solution than I initially envisioned. The heights are saved right in the style object, in each section's `localState` **when the style is saved**.

Consequences:

* Autosizing won't be applied to such styles. Probably not bad per se but I wonder if we should provide a way to reset the saved heights? Or maybe just add an option in the editor to toggle the functionality globally?
* To make this work on remotely updated styles one would have to type something and delete it so the style has a modified state but the code stays the same so the updates keep working automatically.
* If the remote style has changed the order of sections, all bets are off and the new order is chaos.