### PR TITLE
reduce usercss bubble to `U`

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -475,6 +475,10 @@
     "message": "Title",
     "description": "Used in various parts of the UI to indicate the title of something"
   },
+  "genericUI": {
+    "message": "UI",
+    "description": "UI = User Interface, this label is used to label generic UI-related stuff"
+  },
   "genericUnknown": {
     "message": "Unknown",
     "description": "Used in various parts of the UI to indicate if something is unknown (e.g. an unknown date)"
@@ -1075,6 +1079,9 @@
   },
   "optionsResetButton": {
     "message": "Reset options"
+  },
+  "optionsSliders": {
+    "message": "Use sliders to toggle style entries"
   },
   "optionsStylusThemes": {
     "message": "Find a Stylus UI theme"

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -108,6 +108,8 @@ window.INJECTED !== 1 && (() => {
 
     'popupWidth': 246,              // popup width in pixels
 
+    'ui.sliders': true,             // use sliders instead of checkboxes for style entries
+
     'updateInterval': 24,           // user-style automatic update interval, hours (0 = disable)
   };
   const values = clone(defaults);

--- a/manage.html
+++ b/manage.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title i18n-text="manageTitle"></title>
   <link rel="stylesheet" href="global.css">
+  <link rel="stylesheet" href="options/onoffswitch.css">
   <link rel="stylesheet" href="manage/manage.css">
   <link rel="stylesheet" href="manage/config-dialog.css">
   <link rel="stylesheet" href="msgbox/msgbox.css">
-  <link rel="stylesheet" href="options/onoffswitch.css">
   <link rel="stylesheet" href="vendor-overwrites/colorpicker/colorpicker.css">
 
   <style id="firefox-transitions-bug-suppressor">
@@ -58,10 +58,7 @@
   <template data-id="styleNewUI">
     <div class="entry">
       <h2 class="style-name">
-        <div class="checkmate">
-          <input class="checker" type="checkbox" i18n-title="toggleStyle">
-          <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
-        </div>
+        <toggle></toggle>
         <a class="style-name-link">
           &nbsp;
           <span class="style-info" data-type="version"></span>
@@ -81,6 +78,20 @@
         <div class="targets"></div>
         <a href="#" class="expander" tabindex="0">...</a>
       </div>
+    </div>
+  </template>
+
+  <template data-id="toggleChecker">
+    <div class="checkmate">
+      <input class="checker" type="checkbox" i18n-title="toggleStyle">
+      <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
+    </div>
+  </template>
+
+  <template data-id="toggleSlider">
+    <div class="onoffswitch">
+      <input class="slider" type="checkbox" i18n-title="toggleStyle">
+      <span></span>
     </div>
   </template>
 

--- a/manage/config-dialog.css
+++ b/manage/config-dialog.css
@@ -1,3 +1,7 @@
+:root {
+  --onoffswitch-width: 60px;
+}
+
 #stylus-manage .config-dialog #message-box-contents {
   padding: 2em 16px;
 }

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -178,20 +178,6 @@ a:hover {
   text-decoration: none;
 }
 
-.style-info {
-  text-align: right;
-  padding: 0 .25em;
-  font-weight: normal;
-  color: #999;
-}
-.style-info[data-type=version] {
-  color: #666;
-  padding-left: .5em;
-}
-.newUI .style-info[data-type=version][data-value="1.0.0"] {
-  display: none;
-}
-
 .applies-to {
   overflow-wrap: break-word;
 }
@@ -243,40 +229,17 @@ a:hover {
   display: none;
 }
 
-.newUI .style-name::after,
-.newUI .style-name-link::after {
-  vertical-align: text-top;
-}
-
-.disabled h2::after {
-  content: var(--genericDisabledLabel);
-}
-.disabled h2::after,
 .entry.usercss .style-name-link::after {
-  font-weight: normal;
   font-size: 11px;
-  text-transform: lowercase;
-  background: rgba(128, 128, 128, .2);
-  padding: 2px 5px 3px;
   border-radius: 4px;
   margin-left: 1ex;
   white-space: nowrap;
-  position: relative;
-  top: -2px;
-}
-.newUI .disabled h2::after,
-.newUI .entry.usercss .style-name-link::after {
-  top: 2px;
-}
-
-.entry.usercss .style-name-link::after {
-  content: "usercss";
-  background-color: hsla(180, 100%, 20%, 1);
-  color: white;
+  content: "UC";
+  background-color: hsla(180, 35%, 50%, .35);
+  padding: 2px 3px;
 }
 
 .disabled h2 .style-name-link,
-.disabled h2::after,
 .disabled .actions,
 .disabled .applies-to {
   opacity: 0.6;
@@ -376,12 +339,23 @@ a:hover {
   vertical-align: middle;
 }
 
-.newUI .entry > .style-info {
-  padding-right: 1em;
-}
-
 .newUI .entry .actions {
   position: relative;
+}
+
+.style-info[data-type=version] {
+  color: #666;
+  padding-left: .5em;
+  font-weight: normal;
+}
+.newUI .style-info[data-type=version][data-value=""],
+.newUI .style-info[data-type=version][data-value="1.0.0"] {
+  display: none;
+}
+.newUI .entry .style-info[data-type=age] {
+  color: #999;
+  text-align: right;
+  padding-right: 1em;
 }
 
 /************ checkbox & select************/
@@ -1175,7 +1149,6 @@ a:hover {
     padding-right: 0;
   }
 
-  .newUI .style-name::after,
   .newUI .style-name-link::after {
     text-indent: 0;
     display: inline-block;

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -1,10 +1,13 @@
 :root {
   --header-width: 280px;
-  --checkbox-width: 24px;
-  --name-padding-left: 40px;
+  --slider-width: 21px;
+  --name-padding-left: 20px;
   --name-padding-right: 40px;
   --actions-width: 75px;
-  --onoffswitch-width: 60px;
+}
+
+.has-sliders {
+  --name-padding-left: 46px;
 }
 
 body {
@@ -360,10 +363,6 @@ a:hover {
 
 /************ checkbox & select************/
 
-.newUI .checker {
-  margin: 0;
-}
-
 #newUIoptions > div, #newUIoptions > label {
   margin: 4px 0;
 }
@@ -464,7 +463,6 @@ a:hover {
 
 .newUI .style-name {
   font-size: 14px;
-  text-indent: calc(var(--checkbox-width) - var(--name-padding-left) - 4px);
   padding-left: var(--name-padding-left);
   padding-right: var(--name-padding-right);
   position: relative;
@@ -1028,6 +1026,14 @@ a:hover {
 }
 
 @media (max-width: 850px) {
+  :root {
+    --name-padding-left: 34px;
+  }
+
+  .has-sliders {
+    --name-padding-left: 44px;
+  }
+
   body {
     display: table;
   }
@@ -1049,6 +1055,11 @@ a:hover {
 
   #installed {
     table-layout: fixed;
+  }
+
+  .entry .onoffswitch {
+    --slider-width: 20px;
+    padding-left: 14px;
   }
 
   .newUI .entry .actions {
@@ -1131,7 +1142,6 @@ a:hover {
   }
 
   .newUI .entry .style-name {
-    padding: .5rem 0 .5rem 34px;
     text-indent: unset;
   }
 

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -96,7 +96,6 @@ const handleEvent = {};
   // translate CSS manually
   document.styleSheets[0].insertRule(
     `:root {${[
-      'genericDisabledLabel',
       'updateAllCheckSucceededSomeEdited',
       'filteredStylesAllHidden',
     ].map(id => `--${id}:"${CSS.escape(t(id))}";`).join('')
@@ -555,12 +554,12 @@ Object.assign(handleEvent, {
   },
 
   addEntryTitle(link) {
-    const entry = link.closest('.entry');
-    link.title = [
-      {prop: 'installDate', name: 'dateInstalled'},
-      {prop: 'updateDate', name: 'dateUpdated'},
-    ].map(({prop, name}) =>
-      t(name) + ': ' + (t.formatDate(entry.styleMeta[prop]) || '—')).join('\n');
+    const style = link.closest('.entry').styleMeta;
+    const ucd = style.usercssData;
+    link.title =
+      `${t('dateInstalled')}: ${t.formatDate(style.installDate) || '—'}\n` +
+      `${t('dateUpdated')}: ${t.formatDate(style.updateDate) || '—'}\n` +
+      (ucd ? `UserCSS, v.${ucd.version}` : '');
   },
 });
 

--- a/options.html
+++ b/options.html
@@ -180,6 +180,26 @@
         </div>
       </div>
 
+      <div class="block">
+        <h1 i18n-text="genericUI"></h1>
+        <div class="items">
+          <label>
+            <span i18n-text="optionsSliders"></span>
+            <span class="onoffswitch">
+              <input type="checkbox" id="ui.sliders" class="slider">
+              <span></span>
+            </span>
+          </label>
+          <label class="chromium-only">
+            <span i18n-text="optionsAdvancedContextDelete"></span>
+            <span class="onoffswitch">
+              <input type="checkbox" id="editor.contextDelete" class="slider">
+              <span></span>
+            </span>
+          </label>
+        </div>
+      </div>
+
       <div class="block" id="updates">
         <h1 i18n-text="optionsCustomizeUpdate"></h1>
         <div class="items">
@@ -269,13 +289,6 @@
             </span>
             <span class="onoffswitch">
               <input type="checkbox" id="exposeIframes" class="slider">
-              <span></span>
-            </span>
-          </label>
-          <label class="chromium-only">
-            <span i18n-text="optionsAdvancedContextDelete"></span>
-            <span class="onoffswitch">
-              <input type="checkbox" id="editor.contextDelete" class="slider">
               <span></span>
             </span>
           </label>

--- a/options/onoffswitch.css
+++ b/options/onoffswitch.css
@@ -71,3 +71,55 @@
   background-color: #04BA9F;
   box-shadow: 3px 6px 18px 0 rgba(0, 0, 0, 0.2);
 }
+
+.entry .onoffswitch {
+  position: absolute;
+  width: var(--slider-width, 24px);
+  top: 0;
+  left: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0 4px 0 18px;
+}
+.entry .onoffswitch span {
+  position: absolute;
+  width: var(--slider-width, 24px);
+  height: 11px;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  background-color: rgba(128, 128, 128, .2);
+  box-shadow: inset 1px 1px 2px rgba(0, 0, 0, .5);
+  transition: box-shadow .25s;
+  pointer-events: none;
+}
+.entry .onoffswitch input:checked + span {
+  background-color: hsla(180, 50%, 40%, .5);
+}
+.entry .onoffswitch:hover span {
+  box-shadow: inset 1px 1px 3px rgba(0, 0, 0, .8);
+}
+.entry .onoffswitch input {
+  width: 100%;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  margin: 0;
+  cursor: pointer;
+  pointer-events: all;
+}
+.entry .onoffswitch input + span::before {
+  width: 9px;
+  height: 9px;
+  left: 2px;
+  right: auto;
+  margin: auto;
+  background-color: #fff;
+  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.3);
+}
+.entry .onoffswitch input:checked + span::before {
+  left: auto;
+  right: 2px;
+  background-color: #fff;
+  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.3);
+}

--- a/popup.html
+++ b/popup.html
@@ -27,8 +27,7 @@
       <div class="entry-content">
         <div class="main-controls">
           <label class="style-name">
-            <input class="checker" type="checkbox">
-            <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
+            <toggle></toggle>
           </label>
         </div>
         <div class="actions">
@@ -74,6 +73,20 @@
           </div>
         </div>
       </div>
+    </div>
+  </template>
+
+  <template data-id="toggleChecker">
+    <div class="checkmate">
+      <input class="checker" type="checkbox">
+      <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
+    </div>
+  </template>
+
+  <template data-id="toggleSlider">
+    <div class="onoffswitch">
+      <input class="slider" type="checkbox">
+      <span></span>
     </div>
   </template>
 

--- a/popup/hotkeys.js
+++ b/popup/hotkeys.js
@@ -57,7 +57,7 @@ const hotkeys = (() => {
     if (!entry) {
       return;
     }
-    const target = $(shiftKey ? '.style-edit-link' : '.checker', entry);
+    const target = $(shiftKey ? '.style-edit-link' : 'input', entry);
     target.dispatchEvent(new MouseEvent('click', {cancelable: true}));
   }
 
@@ -86,14 +86,14 @@ const hotkeys = (() => {
     let task = Promise.resolve();
     for (let entry of list) {
       entry = typeof entry === 'string' ? $('#' + entry) : entry;
-      if (!match && $('.checker', entry).checked !== enable || entry.classList.contains(match)) {
+      if (!match && $('input', entry).checked !== enable || entry.classList.contains(match)) {
         results.push(entry.id);
         task = task
           .then(() => API.toggleStyle(entry.styleId, enable))
           .then(() => {
             entry.classList.toggle('enabled', enable);
             entry.classList.toggle('disabled', !enable);
-            $('.checker', entry).checked = enable;
+            $('input', entry).checked = enable;
           });
       }
     }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,11 +1,12 @@
 :root {
-  --header-width: 280px;
-  --checkbox-width: 24px;
-  --name-padding-left: 40px;
-  --name-padding-right: 40px;
-  --actions-width: 75px;
-  --onoffswitch-width: 60px;
+  --inner-padding: 18px; /* checkbox + gap */
   --outer-padding: 9px;
+  --hotkey-margin: 16px;
+}
+
+.has-sliders {
+  --inner-padding: 20px;
+  --slider-width: 18px;
 }
 
 html, body {
@@ -35,12 +36,12 @@ body > div:not(#installed):not(#message-box):not(.colorpicker-popup) {
 }
 /************ checkbox ************/
 
-.style-name:hover input[type="checkbox"]:checked {
+.style-name:hover .checker:checked {
   border-color: hsl(0, 0%, 32%);
   background-color: hsl(0, 0%, 82%);
 }
 
-.style-name:hover input[type="checkbox"] {
+.style-name:hover .checker {
   border-color: hsl(0, 0%, 32%);
   background-color: hsl(0, 0%, 82%);
 }
@@ -96,7 +97,7 @@ body > div:not(#installed):not(#message-box):not(.colorpicker-popup) {
 }
 
 #disable-all-wrapper .main-controls label {
-  padding-left: 16px;
+  padding-left: var(--inner-padding);
   position: relative;
   transition: color .25s;
   font-size: 12px;
@@ -126,7 +127,7 @@ a:hover {
 }
 
 .actions > .main-controls {
-  padding-left: 16px;
+  padding-left: var(--inner-padding);
 }
 
 .main-controls {
@@ -178,7 +179,7 @@ body.blocked > DIV {
 }
 
 html[style] .entry-content {
-  padding: 0 16px 0 0;
+  padding: 0 var(--hotkey-margin) 0 0;
 }
 
 #no-styles.entry {
@@ -199,7 +200,7 @@ html[style] .entry-content {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding-left: 26px;
+  padding-left: calc(var(--outer-padding) + var(--inner-padding));
   position: relative;
 }
 
@@ -234,6 +235,10 @@ html[style] .entry-content {
   padding-right: 5px;
 }
 
+.entry .onoffswitch {
+  padding: 0 0 0 6px;
+}
+
 .entry:nth-child(even) {
   background-color: rgba(0, 0, 0, 0.05);
 }
@@ -265,7 +270,7 @@ html[style*="border"] .entry:nth-child(11):before {
 
 .entry .actions > * {
   height: 26px;
-  width: 18px;
+  width: var(--inner-padding);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -849,7 +854,7 @@ body.blocked .actions > .main-controls {
   top: 0;
   right: 0;
   bottom: 0;
-  width: 16px;
+  width: var(--hotkey-margin);
   cursor: help;
   margin: 0;
   padding: 0;

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -221,6 +221,10 @@ html[style] .entry-content {
   opacity: 1;
 }
 
+.entry.disabled .style-name {
+  font-weight: normal;
+}
+
 .entry .main-controls {
   height: 100%;
   display: inline-flex;

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -47,6 +47,11 @@ initTabUrls()
         .map(({url}) => getStyleDataMerged(url).then(styles => ({styles, url}))),
     ]))
   .then(([, ...results]) => {
+    const sliders = prefs.get('ui.sliders');
+    const slot = $('toggle', t.template.style);
+    const toggle = t.template[sliders ? 'toggleSlider' : 'toggleChecker'];
+    slot.parentElement.replaceChild(toggle.cloneNode(true), slot);
+    document.body.classList.toggle('has-sliders', sliders);
     if (results[0]) {
       showStyles(results);
     } else {
@@ -353,7 +358,6 @@ function createStyleElement(style) {
   let entry = $.entry(style);
   if (!entry) {
     entry = t.template.style.cloneNode(true);
-    entry.setAttribute('style-id', style.id);
     Object.assign(entry, {
       id: ENTRY_ID_PREFIX_RAW + style.id,
       styleId: style.id,
@@ -361,12 +365,8 @@ function createStyleElement(style) {
       onmousedown: handleEvent.maybeEdit,
       styleMeta: style,
     });
-    const checkbox = $('.checker', entry);
-    Object.assign(checkbox, {
-      id: ENTRY_ID_PREFIX_RAW + style.id,
-      // title: t('exclusionsPopupTip'),
+    Object.assign($('input', entry), {
       onclick: handleEvent.toggle,
-      // oncontextmenu: handleEvent.openExcludeMenu
     });
     const editLink = $('.style-edit-link', entry);
     Object.assign(editLink, {
@@ -378,7 +378,6 @@ function createStyleElement(style) {
       htmlFor: ENTRY_ID_PREFIX_RAW + style.id,
       onclick: handleEvent.name,
     });
-    styleName.checkbox = checkbox;
     styleName.appendChild(document.createTextNode(' '));
 
     const config = $('.configure', entry);
@@ -415,7 +414,7 @@ function createStyleElement(style) {
 
   entry.classList.toggle('disabled', !style.enabled);
   entry.classList.toggle('enabled', style.enabled);
-  $('.checker', entry).checked = style.enabled;
+  $('input', entry).checked = style.enabled;
 
   const styleName = $('.style-name', entry);
   styleName.lastChild.textContent = style.customName || style.name;
@@ -478,7 +477,7 @@ Object.assign(handleEvent, {
   },
 
   name(event) {
-    this.checkbox.dispatchEvent(new MouseEvent('click'));
+    $('input', this).dispatchEvent(new MouseEvent('click'));
     event.preventDefault();
   },
 


### PR DESCRIPTION
Showing `usercss` was probably warranted at the beginning to introduce the feature but now it's just wasting space and attention so let's reduce it to just `U`:

![image](https://user-images.githubusercontent.com/1310400/99730544-af248300-2acd-11eb-9dda-3730ca5dc22a.png)
