### PR TITLE
faster popup load to avoid resize flicker

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1280,6 +1280,12 @@
     "message": "No styles found for this site.",
     "description": "Error text in the popup when inline search didn't find any site-specific styles"
   },
+  "searchResultNotMatching": {
+    "message": "The style is installed but it doesn't apply to the current site URL."
+  },
+  "searchResultNotMatchingNote": {
+    "message": "Try asking the author of this userstyle to add the URL.\n\nYou can also open the style in the manager and edit it yourself,\nbut be aware it disables automatic updates for this style."
+  },
   "searchResultRating": {
     "message": "Rating",
     "description": "Text for label that shows the search result's rating"

--- a/popup.html
+++ b/popup.html
@@ -25,22 +25,22 @@
           </label>
         </div>
         <div class="actions">
-          <a href="#" class="configure" i18n-title="configureStyle" tabindex="0">
+          <a href="#" class="configure" i18n-title="configureStyle">
             <svg class="svg-icon config"><use xlink:href="#svg-icon-config"></use></svg>
           </a>
-          <a class="style-edit-link" href="edit.html?id=" i18n-title="editStyleLabel" tabindex="0">
+          <a class="style-edit-link" href="edit.html?id=" i18n-title="editStyleLabel">
             <svg class="svg-icon edit" viewBox="0 0 14 16">
               <path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/>
             </svg>
           </a>
-          <a href="#" class="menu-button" i18n-title="popupMenuButtonTooltip" tabindex="0">
+          <a href="#" class="menu-button" i18n-title="popupMenuButtonTooltip">
             <svg class="svg-icon menu-button-icon" viewBox="0 0 3 16">
               <path fill-rule="evenodd" d="M0 2.5a1.5 1.5 0 1 0 3 0 1.5 1.5 0 0 0-3 0zm0 5a1.5 1.5 0 1 0 3 0 1.5 1.5 0 0 0-3 0zM1.5 14a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/>
             </svg>
           </a>
         </div>
       </div>
-      <div class="menu" tabindex="-1">
+      <div class="menu">
         <div class="menu-items-wrapper">
           <b class="menu-title"></b>
           <label class="menu-item exclude-by-domain button">

--- a/popup.html
+++ b/popup.html
@@ -172,6 +172,12 @@
     <div class="search-result-empty"></div>
   </template>
 
+  <template data-id="searchResultNotMatching">
+    <p class="not-matching-explainer"
+       i18n-text="searchResultNotMatching"
+       i18n-title="searchResultNotMatchingNote"></p>
+  </template>
+
   <script src="js/polyfill.js"></script>
   <script src="js/msg.js"></script>
   <script src="js/messaging.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -16,12 +16,6 @@
     }
   </style>
 
-  <!-- Notes:
-    * Chrome doesn't garbage-collect (or even leaks) SVG <symbol> referenced via <use> so we'll embed the code directly
-    * inter-tag whitespace in templates is automatically removed in localization.js
-    * i18n-anything attribute automatically creates "anything" attribute
-  -->
-
   <template data-id="style">
     <div class="entry">
       <div class="entry-content">
@@ -178,33 +172,35 @@
     <div class="search-result-empty"></div>
   </template>
 
-  <link rel="stylesheet" href="vendor-overwrites/colorpicker/colorpicker.css">
-  <script src="vendor-overwrites/colorpicker/colorconverter.js"></script>
-  <script src="vendor-overwrites/colorpicker/colorpicker.js"></script>
-
-  <link rel="stylesheet" href="msgbox/msgbox.css">
-  <script src="msgbox/msgbox.js"></script>
-
-  <link rel="stylesheet" href="options/onoffswitch.css">
-  <link rel="stylesheet" href="manage/config-dialog.css">
-  <script src="manage/config-dialog.js"></script>
-
   <script src="js/polyfill.js"></script>
-  <script src="js/dom.js"></script>
-  <script src="js/messaging.js"></script>
-  <script src="js/localization.js"></script>
   <script src="js/msg.js"></script>
+  <script src="js/messaging.js"></script>
+  <script src="popup/popup-preinit.js"></script>
+
+  <script src="js/dom.js"></script>
+  <script src="js/localization.js"></script>
   <script src="js/prefs.js"></script>
   <script src="content/style-injector.js"></script>
   <script src="content/apply.js"></script>
 
+  <!-- async hack to load auxiliary stylesheets later so they don't delay the UI -->
+  <link rel="stylesheet" href="vendor-overwrites/colorpicker/colorpicker.css" media="print">
+  <link rel="stylesheet" href="msgbox/msgbox.css" media="print">
+  <link rel="stylesheet" href="manage/config-dialog.css" media="print">
+  <link rel="stylesheet" href="popup/search-results.css" media="print">
+  <link rel="stylesheet" href="options/onoffswitch.css">
   <link rel="stylesheet" href="popup/popup.css">
-  <link rel="stylesheet" href="popup/search-results.css">
+
   <script src="popup/popup.js"></script>
   <script src="popup/search-results.js"></script>
   <script src="popup/hotkeys.js"></script>
+
   <script src="js/script-loader.js" async></script>
   <script src="js/storage-util.js" async></script>
+  <script src="vendor-overwrites/colorpicker/colorconverter.js" async></script>
+  <script src="vendor-overwrites/colorpicker/colorpicker.js" async></script>
+  <script src="msgbox/msgbox.js" async></script>
+  <script src="manage/config-dialog.js" async></script>
 </head>
 
 <body id="stylus-popup">

--- a/popup/popup-preinit.js
+++ b/popup/popup-preinit.js
@@ -1,0 +1,87 @@
+/* global
+  API
+  URLS
+*/
+'use strict';
+
+const ABOUT_BLANK = 'about:blank';
+/* exported tabURL */
+/** @type string */
+let tabURL;
+
+/* exported initializing */
+const initializing = (async () => {
+  let [tab] = await browser.tabs.query({currentWindow: true, active: true});
+  if (!chrome.app && tab.status === 'loading' && tab.url === 'about:blank') {
+    tab = await waitForTabUrlFF(tab);
+  }
+  const frames = sortTabFrames(await browser.webNavigation.getAllFrames({tabId: tab.id}));
+  let url = tab.pendingUrl || tab.url || ''; // new Chrome uses pendingUrl while connecting
+  if (url === 'chrome://newtab/' && !URLS.chromeProtectsNTP) {
+    url = frames[0].url || '';
+  }
+  if (!URLS.supported(url)) {
+    url = '';
+    frames.length = 1;
+  }
+  tabURL = frames[0].url = url;
+  const uniqFrames = frames.filter(f => f.url && !f.isDupe);
+  const styles = await Promise.all(uniqFrames.map(getFrameStyles));
+  return {frames, styles};
+
+  async function getFrameStyles({url}) {
+    return {
+      url,
+      styles: await getStyleDataMerged(url),
+    };
+  }
+
+  /** @param {chrome.webNavigation.GetAllFrameResultDetails[]} frames */
+  function sortTabFrames(frames) {
+    const unknown = new Map(frames.map(f => [f.frameId, f]));
+    const known = new Map([[0, unknown.get(0) || {frameId: 0, url: ''}]]);
+    unknown.delete(0);
+    let lastSize = 0;
+    while (unknown.size !== lastSize) {
+      for (const [frameId, f] of unknown) {
+        if (known.has(f.parentFrameId)) {
+          unknown.delete(frameId);
+          if (!f.errorOccurred) known.set(frameId, f);
+          if (f.url === ABOUT_BLANK) f.url = known.get(f.parentFrameId).url;
+        }
+      }
+      lastSize = unknown.size; // guard against an infinite loop due to a weird frame structure
+    }
+    const sortedFrames = [...known.values(), ...unknown.values()];
+    const urls = new Set([ABOUT_BLANK]);
+    for (const f of sortedFrames) {
+      if (!f.url) f.url = '';
+      f.isDupe = urls.has(f.url);
+      urls.add(f.url);
+    }
+    return sortedFrames;
+  }
+
+  function waitForTabUrlFF(tab) {
+    return new Promise(resolve => {
+      browser.tabs.onUpdated.addListener(...[
+        function onUpdated(tabId, info, updatedTab) {
+          if (info.url && tabId === tab.id) {
+            browser.tabs.onUpdated.removeListener(onUpdated);
+            resolve(updatedTab);
+          }
+        },
+        ...'UpdateFilter' in browser.tabs ? [{tabId: tab.id}] : [],
+        // TODO: remove both spreads and tabId check when strict_min_version >= 61
+      ]);
+    });
+  }
+})();
+
+/* Merges the extra props from API into style data.
+ * When `id` is specified returns a single object otherwise an array */
+async function getStyleDataMerged(url, id) {
+  const styles = (await API.getStylesByUrl(url, id))
+    .map(r => Object.assign(r.data, r));
+  return id ? styles[0] : styles;
+}

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -729,11 +729,6 @@ body.blocked .actions > .main-controls {
   display: flex;
 }
 
-#confirm[data-display=true] + #installed .menu[data-display=true] {
-  opacity: 0;
-  pointer-events: none;
-}
-
 #confirm > div {
   width: 80%;
   max-height: 80%;

--- a/popup/search-results.css
+++ b/popup/search-results.css
@@ -36,8 +36,9 @@ body.search-results-shown {
 
 .search-result,
 .search-result-empty {
+  --pad: 8px;
   position: relative;
-  padding: 8px 8px 21px;
+  padding: var(--pad) var(--pad) 21px;
   min-height: 160px;
 }
 
@@ -207,6 +208,14 @@ body.search-results-shown {
   position: absolute;
   width: 100%;
   margin-top: 4px;
+}
+
+.not-matching-explainer {
+  padding: var(--pad);
+  margin: calc(-1 * var(--pad)) calc(-1 * var(--pad)) var(--pad);
+  border-bottom: 2px solid hsla(25, 100%, 60%, .5);
+  background-color: hsla(25, 100%, 60%, .2);
+  cursor: help;
 }
 
 .search-results-nav {

--- a/popup/search-results.js
+++ b/popup/search-results.js
@@ -366,6 +366,15 @@ window.addEventListener('showStyles:done', () => {
       $('.search-result-status', entry).textContent = '';
       hide('.search-result-customize', entry);
     }
+    const notMatching = installedId > 0 && !$.entry(installedId);
+    if (notMatching !== entry.classList.contains('not-matching')) {
+      entry.classList.toggle('not-matching');
+      if (notMatching) {
+        entry.prepend(t.template.searchResultNotMatching.cloneNode(true));
+      } else {
+        entry.firstElementChild.remove();
+      }
+    }
     Object.assign($('.search-result-screenshot', entry), {
       onclick: isInstalled ? uninstall : install,
       title: isInstalled ? '' : t('installButton'),


### PR DESCRIPTION
There's a problem in Chrome: as usual it tries to be fast and paints an empty popup for a fraction of a second, then the data arrives and the popup is resized to accommodate it, which looks fussy and unpleasant. This PR fixes the problem by getting the data earlier.

Nothing I can do to fix the micro-sized popup (like 40x40 px) that Chrome paints occasionally, really rarely.