### PR TITLE
[simple-window editor] embed popup as iframe

### DIFF
--- a/edit/edit.css
+++ b/edit/edit.css
@@ -29,6 +29,35 @@ body {
   display: none !important;
 }
 
+
+/************ embedded popup for simple-window editor ************/
+#popup-iframe {
+  max-height: 600px;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 1001;
+  border: none;
+  background: #fff;
+  box-shadow: 0 0 30px #000;
+}
+#popup-iframe:not([data-loaded]) {
+  opacity: 0;
+}
+#popup-button {
+  position: fixed;
+  right: 7px;
+  top: 11px;
+  z-index: 1000;
+  cursor: pointer;
+  transition: filter .25s;
+}
+#popup-button:hover {
+  filter: drop-shadow(0 0 3px hsl(180, 70%, 50%));
+}
+body:not(.compact-layout) #popup-button {
+  right: 24px;
+}
 /************ checkbox & select************/
 .options-column > div[class="option"] {
   margin-bottom: 4px;

--- a/js/dom.js
+++ b/js/dom.js
@@ -278,6 +278,12 @@ function $create(selector = 'div', properties, children) {
     delete opt.attributes;
   }
 
+  if (opt.style) {
+    if (typeof opt.style === 'string') element.style.cssText = opt.style;
+    if (typeof opt.style === 'object') Object.assign(element.style, opt.style);
+    delete opt.style;
+  }
+
   if (ns) {
     for (const attr in opt) {
       const i = attr.indexOf(':') + 1;


### PR DESCRIPTION
There's a problem with our otherwise cool `simple window` option: browsers can't show the browser_action popup neither via a click nor a hotkey.

This PR adds such a button in the top-right corner and a hotkey: <kbd>Shift</kbd><kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>S</kbd>.

The button looks bad in usercss non-compact mode though so maybe you could find/suggest an acceptable solution @narcolepticinsomniac ? For today, I'm off to sleep.