### PR TITLE
improve autocomplete

### DIFF
--- a/edit/codemirror-default.js
+++ b/edit/codemirror-default.js
@@ -91,12 +91,13 @@
     }
   }
 
-  Object.assign(CodeMirror.mimeModes['text/css'].propertyKeywords, {
+  const cssMime = CodeMirror.mimeModes['text/css'];
+  Object.assign(cssMime.propertyKeywords, {
     'content-visibility': true,
     'overflow-anchor': true,
     'overscroll-behavior': true,
   });
-  Object.assign(CodeMirror.mimeModes['text/css'].colorKeywords, {
+  Object.assign(cssMime.colorKeywords, {
     'darkgrey': true,
     'darkslategrey': true,
     'dimgrey': true,
@@ -104,7 +105,17 @@
     'lightslategrey': true,
     'slategrey': true,
   });
-
+  Object.assign(cssMime.valueKeywords, {
+    'blur': true,
+    'brightness': true,
+    'contrast': true,
+    'cubic-bezier': true,
+    'drop-shadow': true,
+    'fit-content': true,
+    'hue-rotate': true,
+    'saturate': true,
+    'sepia': true,
+  });
   Object.assign(CodeMirror.prototype, {
     /**
      * @param {'less' | 'stylus' | ?} [pp] - any value besides `less` or `stylus` sets `css` mode

--- a/vendor-overwrites/colorpicker/colorview.js
+++ b/vendor-overwrites/colorpicker/colorview.js
@@ -717,7 +717,7 @@
     styles = this.getLineHandle(line).styles,
     pos,
   }) {
-    if (pos < 0) return;
+    if (pos < 0 || !styles) return;
     const len = styles.length;
     const end = styles[len - 2];
     if (pos > end) return;


### PR DESCRIPTION
* correctly handle search overlay if it covers some part of the token
* correctly show props with `@preprocessor stylus`
* show `@` rules and `@-moz-document` functions and some missing filters

So, rather trivial changes but I'm opening a PR anyway for testing because I've rewritten the entire function.