### PR TITLE
convert USO styles to USO-archive on update

### DIFF
--- a/background/navigation-manager.js
+++ b/background/navigation-manager.js
@@ -1,4 +1,4 @@
-/* global CHROME FIREFOX URLS ignoreChromeError */// toolbox.js
+/* global CHROME FIREFOX URLS deepEqual ignoreChromeError */// toolbox.js
 /* global bgReady */// common.js
 /* global msg */
 'use strict';
@@ -6,6 +6,7 @@
 /* exported navMan */
 const navMan = (() => {
   const listeners = new Set();
+  let prevData = {};
 
   chrome.webNavigation.onCommitted.addListener(onNavigation.bind('committed'));
   chrome.webNavigation.onHistoryStateUpdated.addListener(onFakeNavigation.bind('history'));
@@ -20,6 +21,10 @@ const navMan = (() => {
 
   /** @this {string} type */
   async function onNavigation(data) {
+    if (CHROME && data.timeStamp === prevData.timeStamp && deepEqual(data, prevData)) {
+      return; // Chrome bug: listener is called twice with identical data
+    }
+    prevData = data;
     if (CHROME &&
         URLS.chromeProtectsNTP &&
         data.url.startsWith('https://www.google.') &&

--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -47,7 +47,7 @@ const styleMan = (() => {
     _id: () => uuidv4(),
     _rev: () => Date.now(),
   };
-  const DELETE_IF_NULL = ['id', 'customName'];
+  const DELETE_IF_NULL = ['id', 'customName', 'md5Url', 'originalMd5'];
   /** @type {Promise|boolean} will be `true` to avoid wasting a microtask tick on each `await` */
   let ready = init();
 

--- a/background/style-search-db.js
+++ b/background/style-search-db.js
@@ -1,5 +1,5 @@
 /* global API */// msg.js
-/* global URLS debounce stringAsRegExp tryRegExp */// toolbox.js
+/* global RX_META debounce stringAsRegExp tryRegExp */// toolbox.js
 /* global addAPI */// common.js
 'use strict';
 
@@ -10,12 +10,12 @@
 
   const extractMeta = style =>
     style.usercssData
-      ? (style.sourceCode.match(URLS.rxMETA) || [''])[0]
+      ? (style.sourceCode.match(RX_META) || [''])[0]
       : null;
 
   const stripMeta = style =>
     style.usercssData
-      ? style.sourceCode.replace(URLS.rxMETA, '')
+      ? style.sourceCode.replace(RX_META, '')
       : null;
 
   const MODES = Object.assign(Object.create(null), {

--- a/background/usercss-install-helper.js
+++ b/background/usercss-install-helper.js
@@ -1,4 +1,4 @@
-/* global URLS download openURL */// toolbox.js
+/* global RX_META URLS download openURL */// toolbox.js
 /* global addAPI bgReady */// common.js
 /* global tabMan */// msg.js
 'use strict';
@@ -85,7 +85,7 @@ bgReady.all.then(() => {
         !oldUrl.startsWith(URLS.installUsercss)) {
       const inTab = url.startsWith('file:') && !chrome.app;
       const code = await (inTab ? loadFromFile : loadFromUrl)(tabId, url);
-      if (!/^\s*</.test(code) && URLS.rxMETA.test(code)) {
+      if (!/^\s*</.test(code) && RX_META.test(code)) {
         openInstallerPage(tabId, url, {code, inTab});
       }
     }

--- a/background/usercss-manager.js
+++ b/background/usercss-manager.js
@@ -1,5 +1,5 @@
 /* global API */// msg.js
-/* global URLS deepCopy download */// toolbox.js
+/* global RX_META deepCopy download */// toolbox.js
 'use strict';
 
 const usercssMan = {
@@ -15,7 +15,7 @@ const usercssMan = {
   async assignVars(style, oldStyle) {
     const meta = style.usercssData;
     const vars = meta.vars;
-    const oldVars = oldStyle.usercssData.vars;
+    const oldVars = (oldStyle.usercssData || {}).vars;
     if (vars && oldVars) {
       // The type of var might be changed during the update. Set value to null if the value is invalid.
       for (const [key, v] of Object.entries(vars)) {
@@ -51,7 +51,7 @@ const usercssMan = {
 
   async buildCode(style) {
     const {sourceCode: code, usercssData: {vars, preprocessor}} = style;
-    const match = code.match(URLS.rxMETA);
+    const match = code.match(RX_META);
     const i = match.index;
     const j = i + match[0].length;
     const codeNoMeta = code.slice(0, i) + blankOut(code, i, j) + code.slice(j);
@@ -74,7 +74,7 @@ const usercssMan = {
       enabled: true,
       sections: [],
     }, style);
-    const match = code.match(URLS.rxMETA);
+    const match = code.match(RX_META);
     if (!match) {
       return Promise.reject(new Error('Could not find metadata.'));
     }

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -1,7 +1,7 @@
 /* global $ $$ $create $remove messageBoxProxy */// dom.js
 /* global API */// msg.js
 /* global CodeMirror */
-/* global FIREFOX URLS debounce ignoreChromeError sessionStore */// toolbox.js
+/* global FIREFOX RX_META debounce ignoreChromeError sessionStore */// toolbox.js
 /* global MozDocMapper clipString helpPopup rerouteHotkeys showCodeMirrorPopup */// util.js
 /* global createSection */// sections-editor-section.js
 /* global editor */
@@ -358,7 +358,7 @@ function SectionsEditor() {
       lockPageUI(true);
       try {
         const code = popup.codebox.getValue().trim();
-        if (!URLS.rxMETA.test(code) ||
+        if (!RX_META.test(code) ||
             !await getPreprocessor(code) ||
             await messageBoxProxy.confirm(
               t('importPreprocessor'), 'pre-line',

--- a/edit/source-editor.js
+++ b/edit/source-editor.js
@@ -4,7 +4,7 @@
 /* global MozDocMapper */// util.js
 /* global MozSectionFinder */
 /* global MozSectionWidget */
-/* global URLS debounce sessionStore */// toolbox.js
+/* global RX_META debounce sessionStore */// toolbox.js
 /* global chromeSync */// storage-util.js
 /* global cmFactory */
 /* global editor */
@@ -307,7 +307,7 @@ function SourceEditor() {
       if (_cm !== cm) {
         return;
       }
-      const match = text.match(URLS.rxMETA);
+      const match = text.match(RX_META);
       if (!match) {
         return [];
       }

--- a/js/usercss-compiler.js
+++ b/js/usercss-compiler.js
@@ -140,7 +140,12 @@ function simplifyUsercssVars(vars) {
       case 'dropdown':
       case 'image':
         // TODO: handle customized image
-        value = va.options.find(o => o.name === value).value;
+        for (const opt of va.options) {
+          if (opt.name === value) {
+            value = opt.value;
+            break;
+          }
+        }
         break;
       case 'number':
       case 'range':

--- a/manage/import-export.js
+++ b/manage/import-export.js
@@ -1,5 +1,5 @@
 /* global API */// msg.js
-/* global URLS deepEqual isEmptyObj tryJSONparse */// toolbox.js
+/* global RX_META deepEqual isEmptyObj tryJSONparse */// toolbox.js
 /* global changeQueue */// manage.js
 /* global chromeSync */// storage-util.js
 /* global prefs */
@@ -83,7 +83,7 @@ function importFromFile({fileTypeFilter, file} = {}) {
         fReader.onloadend = event => {
           fileInput.remove();
           const text = event.target.result;
-          const maybeUsercss = !/^\s*\[/.test(text) && URLS.rxMETA.test(text);
+          const maybeUsercss = !/^\s*\[/.test(text) && RX_META.test(text);
           if (maybeUsercss) {
             messageBoxProxy.alert(t('dragDropUsercssTabstrip'));
           } else {

--- a/manage/manage.css
+++ b/manage/manage.css
@@ -361,6 +361,7 @@ a:hover {
   padding-left: .5em;
   font-weight: normal;
 }
+.newUI .style-info[data-type=version][data-is-date],
 .newUI .style-info[data-type=version][data-value=""],
 .newUI .style-info[data-type=version][data-value="1.0.0"] {
   display: none;

--- a/manage/render.js
+++ b/manage/render.js
@@ -1,6 +1,6 @@
 /* global $ $$ animateElement scrollElementIntoView */// dom.js
 /* global API */// msg.js
-/* global debounce isEmptyObj sessionStore */// toolbox.js
+/* global URLS debounce isEmptyObj sessionStore */// toolbox.js
 /* global filterAndAppend */// filters.js
 /* global installed newUI */// manage.js
 /* global prefs */
@@ -83,6 +83,11 @@ function createStyleElement({style, name: nameLC}) {
   parts.homepage.href = parts.homepage.title = style.url || '';
   parts.infoVer.textContent = ud ? ud.version : '';
   parts.infoVer.dataset.value = ud ? ud.version : '';
+  if (`${style.updateUrl}`.startsWith(URLS.usoArchiveRaw)) {
+    parts.infoVer.dataset.isDate = '';
+  } else {
+    delete parts.infoVer.dataset.isDate;
+  }
   if (newUI.enabled) {
     createAgeText(parts.infoAge, style);
   } else {

--- a/popup/search.js
+++ b/popup/search.js
@@ -409,7 +409,7 @@
     result.pingbackTimer = setTimeout(download, PINGBACK_DELAY,
       `${URLS.uso}styles/install/${id}?source=stylish-ch`);
 
-    const updateUrl = `${URLS.usoArchiveRaw}usercss/${id}.user.css`;
+    const updateUrl = URLS.makeUsoArchiveCodeUrl(id);
     try {
       const sourceCode = await download(updateUrl);
       const style = await API.usercss.install({sourceCode, updateUrl});


### PR DESCRIPTION
There will be no additional prompts or tooltips shown for this process.
The advanced settings of the style are preserved.

Also fixes #1122 - the author of the style should update it on USO site first, then Stylus will use the embedded UserCSS metadata during the next update check.