### PR TITLE
improve linter info and config popup

### DIFF
--- a/edit/edit.css
+++ b/edit/edit.css
@@ -823,6 +823,11 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
 #message-box.center.lint-config #message-box-contents {
   text-align: left;
 }
+#help-popup .active-linter-rule {
+  font-weight: bold;
+  text-decoration: underline;
+  background-color: rgba(128, 128, 128, .2);
+}
 
 /************ CSS beautifier ************/
 .beautify-options {

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -729,6 +729,12 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
 #help-popup .rules {
   padding: 0 15px;
 }
+#help-popup .rules li {
+  padding-top: .5em;
+}
+#help-popup .rules p {
+  margin: .25em 0;
+}
 #help-popup button {
   margin-right: 3px;
 }

--- a/edit/linter-dialogs.js
+++ b/edit/linter-dialogs.js
@@ -57,6 +57,21 @@
       ]));
     cm = popup.codebox;
     cm.focus();
+    const rulesStr = getActiveRules().join('|');
+    if (rulesStr) {
+      const rx = new RegExp(`"(${rulesStr})"\\s*:`);
+      let line = 0;
+      cm.startOperation();
+      cm.eachLine(({text}) => {
+        const m = rx.exec(text);
+        if (m) {
+          const ch = m.index + 1;
+          cm.markText({line, ch}, {line, ch: ch + m[1].length}, {className: 'active-linter-rule'});
+        }
+        ++line;
+      });
+      cm.endOperation();
+    }
     cm.on('changes', updateConfigButtons);
     updateConfigButtons();
     window.on('closeHelp', onConfigClose, {once: true});
@@ -86,14 +101,19 @@
           rule === 'CssSyntaxError' ? rule : $createLink(baseUrl + rule, rule));
     }
     const header = t('linterIssuesHelp', '\x01').split('\x01');
-    const activeRules = new Set([...linterMan.getIssues()].map(issue => issue.rule));
     helpPopup.show(t('linterIssues'),
       $create([
         header[0], headerLink, header[1],
-        $create('ul.rules', [...activeRules].map(template)),
+        $create('ul.rules', getActiveRules().map(template)),
         $create('button', {onclick: linterMan.showLintConfig}, t('configureStyle')),
       ]));
   };
+
+  function getActiveRules() {
+    const all = [...linterMan.getIssues()].map(issue => issue.rule);
+    const uniq = new Set(all);
+    return [...uniq];
+  }
 
   function getLexicalDepth(lexicalState) {
     let depth = 0;

--- a/edit/linter-dialogs.js
+++ b/edit/linter-dialogs.js
@@ -74,9 +74,9 @@
         const rule = RULES.csslint.find(rule => rule.id === ruleID);
         return rule &&
           $create('li', [
-            $create('b', $createLink(rule.url || baseUrl, rule.name)),
-            $create('br'),
-            rule.desc,
+            $create('b', ruleID + ': '),
+            rule.url ? $createLink(`"${rule.url}"`, rule.name) : $create('span', `"${rule.name}"`),
+            $create('p', rule.desc),
           ]);
       };
     } else {
@@ -91,6 +91,7 @@
       $create([
         header[0], headerLink, header[1],
         $create('ul.rules', [...activeRules].map(template)),
+        $create('button', {onclick: linterMan.showLintConfig}, t('configureStyle')),
       ]));
   };
 


### PR DESCRIPTION
### Linter info

Some trivial tweaks in the popup that opens when clicking `(i)` next to `Issues` heading to alleviate #1170:

* show rule id so the user can configure it
* add "configure" button to show the linter config UI
* add margins between items

![image](https://user-images.githubusercontent.com/1310400/107495364-0b64e380-6ba1-11eb-876c-40cf1d5be6cd.png)

### Linter config

* emphasize active rules

![image](https://user-images.githubusercontent.com/1310400/107495090-ac06d380-6ba0-11eb-85b3-8b3dfc764eec.png)
