### PR TITLE
show time/weekday in tooltip for style entries

### DIFF
--- a/js/localization.js
+++ b/js/localization.js
@@ -153,7 +153,7 @@ Object.assign(t, {
       const now = new Date();
       const newDate = new Date(Number(date) || date);
       const needsYear = newDate.getYear() !== now.getYear();
-      const needsWeekDay = now - newDate <= 7 * 24 * 3600e3;
+      const needsWeekDay = needsTime && (now - newDate <= 7 * 24 * 3600e3);
       const intlKey = `_intl${needsWeekDay ? 'W' : ''}${needsYear ? 'Y' : ''}${needsTime ? 'HM' : ''}`;
       const intl = t[intlKey] ||
         (t[intlKey] = new Intl.DateTimeFormat([chrome.i18n.getUILanguage(), 'en'], {

--- a/manage/events.js
+++ b/manage/events.js
@@ -23,8 +23,8 @@ const Events = {
     const style = link.closest('.entry').styleMeta;
     const ucd = style.usercssData;
     link.title =
-      `${t('dateInstalled')}: ${t.formatDate(style.installDate) || '—'}\n` +
-      `${t('dateUpdated')}: ${t.formatDate(style.updateDate) || '—'}\n` +
+      `${t('dateInstalled')}: ${t.formatDate(style.installDate, true) || '—'}\n` +
+      `${t('dateUpdated')}: ${t.formatDate(style.updateDate, true) || '—'}\n` +
       (ucd ? `UserCSS, v.${ucd.version}` : '');
   },
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1310400/110425917-38c88280-80b6-11eb-9905-4daf408b08f7.png)

The time is always shown.
The day of week is shown for intervals within the past seven days.

Any objections/suggestions?