### PR TITLE
Add options_ui for preference links

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,10 @@
     "identity",
     "<all_urls>"
   ],
+  "options_ui": {
+    "page": "manage.html",
+    "open_in_tab": true
+  },
   "background": {
     "scripts": [
       "js/polyfill.js",


### PR DESCRIPTION
For example, in Firefox's `about:addons` page, you're now able to click the ellipses and select preferences to get to `manage.html`

Fixes #1208