### PR TITLE
Fix #1176 Installing local UserCSS style fails in Firefox

### DIFF
--- a/content/install-hook-usercss.js
+++ b/content/install-hook-usercss.js
@@ -5,11 +5,11 @@ if (typeof window.oldCode !== 'string') {
   window.oldCode = (document.querySelector('body > pre') || document.body).textContent;
   chrome.runtime.onConnect.addListener(port => {
     if (port.name !== 'downloadSelf') return;
-    port.onMessage.addListener(async ({id, force, timer}) => {
+    port.onMessage.addListener(async ({id, force}) => {
       const msg = {id};
       try {
         const code = await (await fetch(location.href, {mode: 'same-origin'})).text();
-        if ((code !== window.oldCode || force) || !(timer && code === window.oldCode)) {
+        if (code !== window.oldCode || force) {
           msg.code = window.oldCode = code;
         }
       } catch (error) {

--- a/content/install-hook-usercss.js
+++ b/content/install-hook-usercss.js
@@ -5,11 +5,11 @@ if (typeof window.oldCode !== 'string') {
   window.oldCode = (document.querySelector('body > pre') || document.body).textContent;
   chrome.runtime.onConnect.addListener(port => {
     if (port.name !== 'downloadSelf') return;
-    port.onMessage.addListener(async ({id, force}) => {
+    port.onMessage.addListener(async ({id, force, timer}) => {
       const msg = {id};
       try {
         const code = await (await fetch(location.href, {mode: 'same-origin'})).text();
-        if (code !== window.oldCode || force) {
+        if ((code !== window.oldCode || force) || !(timer && code === window.oldCode)) {
           msg.code = window.oldCode = code;
         }
       } catch (error) {

--- a/install-usercss/preinit.js
+++ b/install-usercss/preinit.js
@@ -19,7 +19,7 @@ const preinit = (() => {
       .catch(getData);
   } else {
     getData = PortDownloader();
-    firstGet = getData({timer: false});
+    firstGet = getData({force: true});
   }
 
   function DirectDownloader() {


### PR DESCRIPTION
Following discussion in #1176 I've used `git bisect` to find the first failing commit as @tophf suggested. Starting from last good version `v1.5.13` reported by @vednoc I've arrived at commit 707cd6576f2d930211be50f21362027b6cb9e873 as the first bad commit.

From what I was able to get reading the code and reproducing the error state shown on [screenshot from original report](https://user-images.githubusercontent.com/18245694/107519428-8da8d400-6bb0-11eb-8df0-740161ec7c88.png), it looks like the error comes from changing the logic in `downloadSelf` event listener.

Old code used this condition for determining when to fill in `code` value of the msg passed:

```
.then(code => ({id, code: timer && code === self.oldCode ? null : code}))
```

while new logic uses something like this (note the use of `force` flag instead of `timer` and somewhat inverse nature of the logic):

```
.then(code => ({id, code: force || code !== self.oldCode ? code : null}))
```

What this patch does is applying both approaches: using `force` flag and using `timer` flag at the same time. As I am myself affected by this bug, and was able to successfully mitigate it in my environment (latest FireFox v87.0 on Linux), I can confirm that it solves the issue and now I'm able to install local files on FireFox again with this patch.

Please let me know if this pull request needs more formatting or additional commits, as the [contributions page](https://github.com/openstyles/stylus/blob/master/.github/CONTRIBUTING.md#pull-requests) didn't mention anything specific aside from `.editorconfig` codestyle which I think I didn't break here.

P.S.: There's a 39c1d61e11b78d5343218591ac7f5848cb3e82bb commit which claims to fix #1176 as well, but according to my tests it doesn't make much difference to help the bug and didn't actually solve it.