### PR TITLE
Add USw hook to remove get stylus button

### DIFF
--- a/content/install-hook-userstylesworld.js
+++ b/content/install-hook-userstylesworld.js
@@ -1,0 +1,41 @@
+/* global API */// msg.js
+'use strict';
+
+(() => {
+  function watchForStylusButton() {
+    // Use 1 function so we won't have duplicate code around.
+    const stylusQuery = () => document.querySelector("a#stylus");
+
+    if (!stylusQuery()) {
+        const stylusButtonObserver = new MutationObserver(() => {
+          if (stylusQuery()) {
+              stylusButtonObserver.disconnect();
+              stylusQuery().remove();
+            }
+        });
+        stylusButtonObserver.observe(document.body, {childList: true, subtree: true});
+    } else {
+      stylusQuery().remove();
+    }
+  }
+
+  // Some trickery to make sure that the DOM is ready(document.body/document.head).
+  // And can possibly observe it for a stylus button.
+
+  function isDOMReady() {
+    return document.readyState === 'complete' || document.readyState === 'interactive';
+  }
+
+  if (!isDOMReady()) {
+    const onReadyStateChange = () => {
+      if (isDOMReady()) {
+        document.removeEventListener('readystatechange', onReadyStateChange);
+        watchForStylusButton();
+      }
+    };
+    document.addEventListener('readystatechange', onReadyStateChange);
+  } else {
+    watchForStylusButton();
+  }
+  
+})()

--- a/manifest.json
+++ b/manifest.json
@@ -89,6 +89,12 @@
       "run_at": "document_start",
       "all_frames": false,
       "js": ["content/install-hook-openusercss.js"]
+    },
+    {
+      "matches": ["https://userstyles.world/style/*"],
+      "run_at": "document_start",
+      "all_frames": false,
+      "js": ["content/install-hook-userstylesworld.js"]
     }
   ],
   "browser_action": {


### PR DESCRIPTION
This patch add an hook into the https://userstyles.world/style/* pages to watch for the Get Stylus button and removes it.
As user's who already have stylus installed don't need to see this again.
@vednoc If you want to follow the PR 🤷🏽‍♀️ 

ex link: https://userstyles.world/style/10/github-dark

Before:
![image](https://user-images.githubusercontent.com/25481501/116686372-00596c80-a9b4-11eb-9c95-cf8bd50dedc9.png)

After:
![image](https://user-images.githubusercontent.com/25481501/116686311-eddf3300-a9b3-11eb-8dfb-6940586dda09.png)

