### PR TITLE
Add code-style command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "lint": "eslint \"**/*.js\" --cache",
+    "code-style": "eslint \"**/*.js\" --fix --cache",
     "test": "node tools/test.js && npm run lint",
     "update-locales": "tx pull --all && node tools/fix-transifex.js",
     "update-transifex": "tx push -s",


### PR DESCRIPTION
- This patch adds a new command `code-style` that has the extra argument of --fix, which tries to fix, "fixable" linting rules and fixes them, for non-fixable rules it can be done manual, but a simple command to eliminate 80% linting issues is a handy tool in my eyes.

Note: just a personal thing as I run into linting issues more often in this project due to unfamiliarity with this type of code styling.