### PR TITLE
Disable Offscreencanvas for firefox

### DIFF
--- a/background/icon-manager.js
+++ b/background/icon-manager.js
@@ -132,7 +132,7 @@ const iconMan = (() => {
 
   // Caches imageData for icon paths
   async function loadImage(url) {
-    const {OffscreenCanvas} = self.createImageBitmap && self || {};
+    const {OffscreenCanvas} = !FIREFOX && self.createImageBitmap && self || {};
     const img = OffscreenCanvas
       ? await createImageBitmap(await (await fetch(url)).blob())
       : await new Promise((resolve, reject) =>


### PR DESCRIPTION
Currently the offscreencanvas is being used for '2d' context, however Firefox(when enabled in `about:config` `gfx.offscreencanvas.enabled`) doesn't implement this as for now, see: https://searchfox.org/mozilla-central/source/dom/canvas/OffscreenCanvas.cpp#105-110 and it will error out multiple times within the console.