### PR TITLE
Fix integration

### DIFF
--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -378,12 +378,18 @@ const styleMan = (() => {
             for (const {style: someStyle} of dataMap.values()) {
               if (someStyle._id === style._id) {
                 someStyle._isUswLinked = true;
-                someStyle.sourceCode = style.sourceCode;
-                const {metadata} = await API.worker.parseUsercssMeta(style.sourceCode);
+                someStyle.originialValue = style.sourceCode;
+                let metadata = {};
+                try {
+                  const {metadata: tmpMetadata} = await API.worker.parseUsercssMeta(style.sourceCode);
+                  metadata = tmpMetadata;
+                } catch (err) {
+                  console.log(err);
+                }
                 someStyle.metadata = metadata;
               } else {
                 delete someStyle._isUswLinked;
-                delete someStyle.sourceCode;
+                delete someStyle.originialValue;
                 delete someStyle.metadata;
               }
               handleSave(await saveStyle(someStyle), null, null, false);
@@ -393,7 +399,7 @@ const styleMan = (() => {
             };
 
             delete style._isUswLinked;
-            delete style.sourceCode;
+            delete style.originialValue;
             delete style.metadata;
             for (const [k, v] of Object.entries(await retrieveStyleInformation(style._usw.token))) {
               style._usw[k] = v;

--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -378,7 +378,7 @@ const styleMan = (() => {
             for (const {style: someStyle} of dataMap.values()) {
               if (someStyle._id === style._id) {
                 someStyle._isUswLinked = true;
-                someStyle.originialValue = style.sourceCode;
+                someStyle.originalValue = style.sourceCode;
                 let metadata = {};
                 try {
                   const {metadata: tmpMetadata} = await API.worker.parseUsercssMeta(style.sourceCode);
@@ -389,7 +389,7 @@ const styleMan = (() => {
                 someStyle.metadata = metadata;
               } else {
                 delete someStyle._isUswLinked;
-                delete someStyle.originialValue;
+                delete someStyle.originalValue;
                 delete someStyle.metadata;
               }
               handleSave(await saveStyle(someStyle), null, null, false);
@@ -399,7 +399,7 @@ const styleMan = (() => {
             };
 
             delete style._isUswLinked;
-            delete style.originialValue;
+            delete style.originalValue;
             delete style.metadata;
             for (const [k, v] of Object.entries(await retrieveStyleInformation(style._usw.token))) {
               style._usw[k] = v;

--- a/content/install-hook-userstylesworld.js
+++ b/content/install-hook-userstylesworld.js
@@ -19,6 +19,7 @@
 
       if (location.pathname === '/api/oauth/style/new') {
         API.styles.find({_isUswLinked: true}).then(style => {
+          style.sourceCode = style.originialValue;
           sendPostMessage({type: 'usw-fill-new-style', data: style});
         });
       }

--- a/content/install-hook-userstylesworld.js
+++ b/content/install-hook-userstylesworld.js
@@ -19,7 +19,7 @@
 
       if (location.pathname === '/api/oauth/style/new') {
         API.styles.find({_isUswLinked: true}).then(style => {
-          style.sourceCode = style.originialValue;
+          style.sourceCode = style.originalValue;
           sendPostMessage({type: 'usw-fill-new-style', data: style});
         });
       }


### PR DESCRIPTION
- Don't use sourceCode as "temporary" value as it's being used as legit value(consider that we delete it after it's non longer needed).
- Wrap the metadata into a `try {}` as some styles doesn't have any metadata.

Thanks @narcolepticinsomniac for testing it out first.