### PR TITLE
Passing `object` -> Passing `property`

### DIFF
--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -395,7 +395,7 @@ const styleMan = (() => {
               handleSave(await saveStyle(someStyle), null, null, false);
             }
             style._usw = {
-              token: await tokenMan.getToken('userstylesworld', true, style),
+              token: await tokenMan.getToken('userstylesworld', true, style.id),
             };
 
             delete style._isUswLinked;

--- a/background/token-manager.js
+++ b/background/token-manager.js
@@ -78,8 +78,8 @@ const tokenMan = (() => {
       return AUTH[name].clientId;
     },
 
-    async getToken(name, interactive, style) {
-      const k = tokenMan.buildKeys(name, style.id);
+    async getToken(name, interactive, styleId) {
+      const k = tokenMan.buildKeys(name, styleId);
       const obj = await chromeLocal.get(k.LIST);
       if (obj[k.TOKEN]) {
         if (!obj[k.EXPIRE] || Date.now() < obj[k.EXPIRE]) {


### PR DESCRIPTION
- Resolves #1276
- Just pass the parameter which is either undefined or an number. No need to get it from a object, while we can just pass the property already.