### PR TITLE
Show error to user when USw returns error

### DIFF
--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -372,7 +372,7 @@ const styleMan = (() => {
           handleSave(await saveStyle(style), {reason: 'success-revoke', codeIsUpdated: true});
           break;
 
-        case 'publish':
+        case 'publish': {
           if (!style._usw || !style._usw.token) {
             // Ensures just the style does have the _isUswLinked property as `true`.
             for (const {style: someStyle} of dataMap.values()) {
@@ -406,8 +406,15 @@ const styleMan = (() => {
             }
             handleSave(await saveStyle(style), {reason: 'success-publishing', codeIsUpdated: true});
           }
-          uploadStyle(style);
+
+          const returnResult = await uploadStyle(style);
+          // USw prefix errors with `Error:`.
+          if (returnResult.startsWith('Error:')) {
+            style._usw.publishingError = returnResult;
+            handleSave(await saveStyle(style), {reason: 'publishing-failed', codeIsUpdated: true});
+          }
           break;
+        }
       }
     });
   }

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -65,6 +65,9 @@ msg.onExtension(request => {
               if (['success-publishing', 'success-revoke'].includes(request.reason)) {
                 updateUI(newStyle);
               }
+              if (request.reason === 'publishing-failed') {
+                messageBoxProxy.alert(`UserStyles.world returned error: ${newStyle._usw.publishingError}`);
+              }
             });
         }
       }

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -66,7 +66,8 @@ msg.onExtension(request => {
                 updateUI(newStyle);
               }
               if (request.reason === 'publishing-failed') {
-                messageBoxProxy.alert(`UserStyles.world returned error: ${newStyle._usw.publishingError}`);
+                messageBoxProxy.alert(newStyle._usw.publishingError, 'pre',
+                  'UserStyles.world: ' + t('genericError'));
               }
             });
         }


### PR DESCRIPTION
As we somehow forgot to add some basic metadata checks to the server, we've now enabled it and added some more errors. In such situations the errors should been shown to the user to understand what's happening.

Related USw commit: https://github.com/userstyles-world/userstyles.world/commit/7c6d2c519b4021c409721d909741c0e4bac0c334

Also I've noticed that messageBox.show() doesn't handle `\n`?

![image](https://user-images.githubusercontent.com/25481501/126052200-b68dadf1-ce38-4160-96be-2067d1ab1a42.png)

@vednoc FYI
