### PR TITLE
Send requested info

### DIFF
--- a/content/install-hook-userstylesworld.js
+++ b/content/install-hook-userstylesworld.js
@@ -12,16 +12,35 @@
 
   const onPageLoaded = event => {
     if (event.data
-    && event.data.type === 'usw-ready'
     && allowedOrigin === event.origin
     ) {
-      sendPostMessage({type: 'usw-remove-stylus-button'});
+      switch (event.data.type) {
+        case 'usw-ready': {
+          sendPostMessage({type: 'usw-remove-stylus-button'});
 
-      if (location.pathname === '/api/oauth/style/new') {
-        const styleId = Number(new URLSearchParams(location.search).get('vendor_data'));
-        API.data.pop('usw' + styleId).then(data => {
-          sendPostMessage({type: 'usw-fill-new-style', data});
-        });
+          if (location.pathname === '/api/oauth/style/new') {
+            const styleId = Number(new URLSearchParams(location.search).get('vendor_data'));
+            API.data.pop('usw' + styleId).then(data => {
+              sendPostMessage({type: 'usw-fill-new-style', data});
+            });
+          }
+          break;
+        }
+        case 'usw-style-info-request': {
+          switch (event.data.requestType) {
+            case 'installed': {
+              API.styles.find({updateUrl: `https://userstyles.world/api/style/${event.data.styleID}.user.css`})
+                .then(style => {
+                  sendPostMessage({
+                    type: 'usw-style-info-response',
+                    data: {installed: Boolean(style), requestType: 'installed'},
+                  });
+                });
+              break;
+            }
+          }
+          break;
+        }
       }
     }
   };


### PR DESCRIPTION
Add the "architecture" for style-request which currently only is "installed" but and probably will expand in the future. 

The "installed" message is now used to add the "Write a review" button and to change the "Install" button's text to "Reinstall".

Related USw commit: https://github.com/userstyles-world/userstyles.world/commit/2d3b0e0281508e44b0d7ca74dbd42e7c08ee6d6c

@FreeplayG - this is 1 of the pieces for the "Write a review" suggestion you had.  So follow the PR if you'd like.

Topfh - As I can't really bother by giving myself a hard time naming variable, I just chose a generic name and gave a little more specific "type" to describe what USw is requesting. Also this is something we don't request in pair of `usw-ready` as this one is only requesting when the user is on the a style's page, so it already requires a different type.