### PR TITLE
patchCSP option: allow `@import` from any URL

### DIFF
--- a/background/style-via-webrequest.js
+++ b/background/style-via-webrequest.js
@@ -112,8 +112,8 @@
     // Allow style assets
     patchCspSrc(src, 'img-src', 'data:', '*');
     patchCspSrc(src, 'font-src', 'data:', '*');
-    // Allow our DOM styles
-    patchCspSrc(src, 'style-src', "'unsafe-inline'");
+    // Allow our DOM styles, allow @import from any URL
+    patchCspSrc(src, 'style-src', "'unsafe-inline'", '*');
     // Allow our XHR cookies in CSP sandbox (known case: raw github urls)
     if (src.sandbox && !src.sandbox.includes('allow-same-origin')) {
       src.sandbox.push('allow-same-origin');


### PR DESCRIPTION
Hopefully, it's an acceptable way to fix (even if partially) #1296.