### PR TITLE
refactor usw content script

### DIFF
--- a/content/install-hook-userstylesworld.js
+++ b/content/install-hook-userstylesworld.js
@@ -29,9 +29,9 @@
     },
   });
 
-  window.addEventListener('message', ({data, source}) => {
-    // Accepting events only from this page.
-    if (data && source === window) {
+  window.addEventListener('message', ({data, source, origin}) => {
+    // Some browser don't reveal `source` to extensions e.g. Firefox
+    if (data && (source ? source === window : origin === ORIGIN)) {
       const fn = HANDLERS[data.type];
       if (fn) fn(data);
     }


### PR DESCRIPTION
* extract handlers to async functions
* limit event source to the current window
* the event's origin is not checked because this content script runs only on allowed origins

@Gusted, please check if I missed or borked something. I'm opening this PR since my suggestion to use `switch` didn't seem to be an improvement so this time I've used a map of handlers just like we do in our `API`.