### PR TITLE
update USO-archive urls

### DIFF
--- a/background/update-manager.js
+++ b/background/update-manager.js
@@ -277,7 +277,7 @@ const updateMan = (() => {
     }
 
     function getDateFromVer(style) {
-      const m = style.updateUrl.startsWith(URLS.usoArchiveRaw) &&
+      const m = URLS.extractUsoArchiveId(style.updateUrl) &&
         style.usercssData.version.match(RX_DATE2VER);
       if (m) {
         m[2]--; // month is 0-based in `Date` constructor

--- a/background/usercss-install-helper.js
+++ b/background/usercss-install-helper.js
@@ -35,10 +35,9 @@ bgReady.all.then(() => {
 
   chrome.webRequest.onBeforeSendHeaders.addListener(maybeInstallFromDistro, {
     urls: [
-      URLS.usoArchiveRaw + 'usercss/*.user.css',
       URLS.usw + 'api/style/*.user.css',
-      '*://greasyfork.org/scripts/*/code/*.user.css',
-      '*://sleazyfork.org/scripts/*/code/*.user.css',
+      ...URLS.usoArchiveRaw.map(s => s + 'usercss/*.user.css'),
+      ...['greasy', 'sleazy'].map(s => `*://${s}fork.org/scripts/*/code/*.user.css`),
       ...[].concat(
         ...Object.entries(maybeDistro)
           .map(([host, {glob}]) => makeUsercssGlobs(host, glob))),

--- a/js/toolbox.js
+++ b/js/toolbox.js
@@ -77,20 +77,23 @@ const URLS = {
   uso: 'https://userstyles.org/',
   usoJson: 'https://userstyles.org/styles/chrome/',
 
-  usoArchive: 'https://33kk.github.io/uso-archive/',
-  usoArchiveRaw: 'https://raw.githubusercontent.com/33kk/uso-archive/flomaster/data/',
+  usoArchive: 'https://uso.kkx.one/',
+  usoArchiveRaw: [
+    'https://cdn.jsdelivr.net/gh/33kk/uso-archive@flomaster/data/',
+    'https://raw.githubusercontent.com/33kk/uso-archive/flomaster/data/',
+  ],
 
   usw: 'https://userstyles.world/',
 
   extractUsoArchiveId: url =>
     url &&
-    url.startsWith(URLS.usoArchiveRaw) &&
+    URLS.usoArchiveRaw.some(u => url.startsWith(u)) &&
     Number(url.match(/\/(\d+)\.user\.css|$/)[1]),
   extractUsoArchiveInstallUrl: url => {
     const id = URLS.extractUsoArchiveId(url);
-    return id ? `${URLS.usoArchive}?style=${id}` : '';
+    return id ? `${URLS.usoArchive}/style/${id}` : '';
   },
-  makeUsoArchiveCodeUrl: id => `${URLS.usoArchiveRaw}usercss/${id}.user.css`,
+  makeUsoArchiveCodeUrl: id => `${URLS.usoArchiveRaw[0]}usercss/${id}.user.css`,
 
   extractGreasyForkInstallUrl: url =>
     /^(https:\/\/(?:greasy|sleazy)fork\.org\/scripts\/\d+)[^/]*\/code\/[^/]*\.user\.css$|$/.exec(url)[1],

--- a/manage/render.js
+++ b/manage/render.js
@@ -83,7 +83,7 @@ function createStyleElement({style, name: nameLC}) {
   parts.homepage.href = parts.homepage.title = style.url || '';
   parts.infoVer.textContent = ud ? ud.version : '';
   parts.infoVer.dataset.value = ud ? ud.version : '';
-  if (`${style.updateUrl}`.startsWith(URLS.usoArchiveRaw)) {
+  if (URLS.extractUsoArchiveId(style.updateUrl)) {
     parts.infoVer.dataset.isDate = '';
   } else {
     delete parts.infoVer.dataset.isDate;

--- a/popup/search.js
+++ b/popup/search.js
@@ -278,7 +278,7 @@
       ai: authorId,
       an: author,
       sa: shotArchived,
-      sn: shotName,
+      sn: shot,
       isUsw,
     } = entry._result = result;
     entry.id = RESULT_ID_PREFIX + id;
@@ -293,14 +293,14 @@
     // screenshot
     const elShot = $('.search-result-screenshot', entry);
     if (isUsw) {
-      elShot.src = !/^https?:/i.test(shotName) ? BLANK_PIXEL :
-        imgType !== '.jpg' ? shotName.replace(/\.jpg$/, imgType) :
-          shotName;
+      elShot.src = !/^https?:/i.test(shot) ? BLANK_PIXEL :
+        imgType !== '.jpg' ? shot.replace(/\.jpg$/, imgType) :
+          shot;
     } else {
       const auto = URLS.uso + `auto_style_screenshots/${id}${USO_AUTO_PIC_SUFFIX}`;
       Object.assign(elShot, {
-        src: shotName && !shotName.endsWith(USO_AUTO_PIC_SUFFIX)
-          ? `${shotArchived ? URLS.usoArchiveRaw[0] : URLS.uso + 'style_'}screenshots/${shotName}`
+        src: shot && !shot.endsWith(USO_AUTO_PIC_SUFFIX)
+          ? `${shotArchived ? URLS.usoArchiveRaw[0] : URLS.uso + 'style_'}screenshots/${shot}`
           : auto,
         _src: auto,
         onerror: fixScreenshot,
@@ -310,9 +310,8 @@
     Object.assign($('[data-type="author"] a', entry), {
       textContent: author,
       title: author,
-      href: isUsw
-        ? `${URLS.usw}user/${encodeURIComponent(author)}`
-        : `${URLS.usoArchive}browse/styles/?search=%40${authorId}`,
+      href: isUsw ? `${URLS.usw}user/${encodeURIComponent(author)}` :
+        `${URLS.usoArchive}browse/styles/?search=%40${authorId}`,
       onclick: Events.openURLandHide,
     });
     // rating

--- a/popup/search.js
+++ b/popup/search.js
@@ -86,12 +86,11 @@
         Events.openURLandHide.call(this, event);
       },
       async prefetchAuthorId() {
-        return this._fetch || (this._fetch = new Promise(async resolve => {
-          const url = `${URLS.usoArchiveRaw[0]}styles/${this._id}.json`;
-          const json = await (await fetch(url)).json();
-          this.href = makeUsoArchiveAuthorUrl(json.info.author.id);
-          resolve();
-        }));
+        return this._fetch || (
+          this._fetch = fetch(`${URLS.usoArchiveRaw[0]}styles/${this._id}.json`)
+            .then(r => r.json())
+            .then(json => (this.href = makeUsoArchiveAuthorUrl(json.info.author.id)))
+        );
       },
     },
   });

--- a/popup/search.js
+++ b/popup/search.js
@@ -64,7 +64,6 @@
   const $class = sel => (sel instanceof Node ? sel : $(sel)).classList;
   const show = sel => $class(sel).remove('hidden');
   const hide = sel => $class(sel).add('hidden');
-  const makeUsoArchiveAuthorUrl = a => `${URLS.usoArchive}browse/styles/?search=%40${a}`;
 
   Object.assign(Events, {
     /**
@@ -84,21 +83,6 @@
       init();
       calcCategory();
       ready = start();
-    },
-
-    usoArchive: {
-      async openAuthor(event) {
-        event.preventDefault();
-        await Events.usoArchive.prefetchAuthorId.call(this);
-        Events.openURLandHide.call(this, event);
-      },
-      async prefetchAuthorId() {
-        return this._fetch || (
-          this._fetch = fetch(`${URLS.usoArchiveRaw[0]}styles/${this._id}.json`)
-            .then(r => r.json())
-            .then(json => (this.href = makeUsoArchiveAuthorUrl(json.info.author.id)))
-        );
-      },
     },
   });
 
@@ -291,6 +275,7 @@
       u: updateTime,
       w: weeklyInstalls,
       t: totalInstalls,
+      ai: authorId,
       an: author,
       sa: shotArchived,
       sn: shotName,
@@ -322,18 +307,13 @@
       });
     }
     // author
-    const eAuthor = encodeURIComponent(author);
     Object.assign($('[data-type="author"] a', entry), {
       textContent: author,
       title: author,
-    }, isUsw ? {
-      href: `${URLS.usw}user/${eAuthor}`,
+      href: isUsw
+        ? `${URLS.usw}user/${encodeURIComponent(author)}`
+        : `${URLS.usoArchive}browse/styles/?search=%40${authorId}`,
       onclick: Events.openURLandHide,
-    } : {
-      _id: id,
-      href: makeUsoArchiveAuthorUrl(eAuthor),
-      onclick: Events.usoArchive.openAuthor,
-      onmousedown: Events.usoArchive.prefetchAuthorId,
     });
     // rating
     $('[data-type="rating"]', entry).dataset.class =

--- a/popup/search.js
+++ b/popup/search.js
@@ -311,7 +311,7 @@
       textContent: author,
       title: author,
       href: isUsw ? `${URLS.usw}user/${encodeURIComponent(author)}` :
-        `${URLS.usoArchive}browse/styles/?search=%40${authorId}`,
+        `${URLS.usoArchive}browse/styles?search=%40${authorId}`,
       onclick: Events.openURLandHide,
     });
     // rating


### PR DESCRIPTION
@33kk, could you please take a look at this PR as we want to use your new USO-archive URLs (including CDN) to avoid a couple of minor issues: flashing of the old address during redirection and flashing of style text when installing from the site page.

Questions:
1. I have to prefetch a big style json when the author label is clicked to get its id. This can be solved by a) adding `ai` to the index but it's rarely used so I'm not keen on this idea, b) adding a search mode `browse/styles/?author-for=${styleId}` so your site's page will download the json, extract the author id, and show the results, c) split your json to ###.meta.json without CSS and ###.css with just the css and no usercss header, by the way who uses this css in json?
2. Do you plan to change the USO-archive URLs anytime soon? When you do, could you inform us beforehand and/or maintain the redirection for a while until we publish a new version of Stylus just like you do currently with the old site?