### PR TITLE
show action hints on preview-less search results

### DIFF
--- a/js/dom.js
+++ b/js/dom.js
@@ -337,10 +337,11 @@ async function showSpinner(parent) {
 }
 
 function toggleDataset(el, prop, state) {
+  const wasEnabled = el.dataset[prop] != null; // avoids mutating DOM unnecessarily
   if (state) {
-    el.dataset[prop] = '';
+    if (!wasEnabled) el.dataset[prop] = '';
   } else {
-    delete el.dataset[prop];
+    if (wasEnabled) delete el.dataset[prop];
   }
 }
 

--- a/popup.html
+++ b/popup.html
@@ -104,9 +104,9 @@
         <img class="search-result-screenshot" i18n-title="installButton">
         <div class="search-result-status"></div>
         <div class="search-result-actions">
-          <button class="search-result-install hidden" i18n-text="installButton"></button>
-          <button class="search-result-uninstall hidden" i18n-text="deleteStyleLabel"></button>
-          <button class="search-result-customize hidden" i18n-text="configureStyle"></button>
+          <button class="search-result-install" i18n-text="installButton"></button>
+          <button class="search-result-uninstall" i18n-text="deleteStyleLabel"></button>
+          <button class="search-result-customize" i18n-text="configureStyle"></button>
         </div>
         <dl class="search-result-meta">
           <div data-type="author">

--- a/popup/search.css
+++ b/popup/search.css
@@ -102,7 +102,7 @@ body.search-results-shown {
   position: relative;
 }
 
-.search-result[data-installed] .search-result-status {
+.search-result .search-result-status {
   top: 0;
   left: 0;
   right: 0;
@@ -114,9 +114,16 @@ body.search-results-shown {
   transition: background-color .5s;
   pointer-events: none;
 }
-
+.search-result[data-no-image] .search-result-status {
+  line-height: 140px;
+}
+.search-result[data-no-image]:not([data-installed]) .search-result-status {
+  background-color: rgba(128, 128, 128, .1);
+  color: currentColor;
+}
 .search-result-screenshot:hover ~ .search-result-status {
   background-color: hsla(180, 100%, 27%, 1);
+  color: #fff;
 }
 
 .search-result-actions {
@@ -131,15 +138,21 @@ body.search-results-shown {
   opacity: 0;
   transition: opacity .5s;
 }
-
 .search-result:not([data-installed]):hover .search-result-actions {
   opacity: 1;
 }
-
 .search-result-actions button {
   box-shadow: 2px 2px 20px #000;
   white-space: nowrap;
   margin: 3px;
+}
+.search-result[data-no-image] .search-result-actions button {
+  box-shadow: none;
+}
+.search-result-install,
+.search-result-uninstall,
+.search-result:not([data-customizable]) .search-result-customize {
+  display: none;
 }
 
 .search-result-meta {

--- a/popup/search.css
+++ b/popup/search.css
@@ -151,8 +151,12 @@ body.search-results-shown {
 }
 .search-result-install,
 .search-result-uninstall,
+.search-result:not([data-installed]) .search-result-customize,
 .search-result:not([data-customizable]) .search-result-customize {
   display: none;
+}
+.search-result.not-matching .search-result-customize {
+  opacity: .5;
 }
 
 .search-result-meta {


### PR DESCRIPTION
* show action hints for results that don't have a preview image
* pure CSS to control visibility of action buttons instead of hardcoded calls to show()/hide().

To see it in action, invoke the inline search on any github page. In the default sort order by updated date you'll see many such styles right away, all from USW so maybe @Gusted could investigate why USW's index contains non-existent preview urls.

![image](https://user-images.githubusercontent.com/1310400/129336953-836f0ad5-3626-4d5c-8bcb-eb308f3118d6.png)