### PR TITLE
keep the original color format in usercss @var

### DIFF
--- a/js/meta-parser.js
+++ b/js/meta-parser.js
@@ -36,7 +36,7 @@ const metaParser = (() => {
             index: state.valueIndex,
           });
         }
-        state.value = colorConverter.format(color, 'rgb');
+        state.value = colorConverter.format(color);
       },
     },
   };


### PR DESCRIPTION
Previously, resetting a color in usercss config dialog would always use `rgb` format.
This PR uses the original color format e.g. hex, rgb, hsla.

@eight04, since it was your commit 3daff40acfcb3cf07ea979dbe9e689256b9b764f, do you remember why? Will something break if the default color is not rgb? AFAICT, there's no problem because we use colorConverter to render the final value.

The change will be applied only when this style is updated/edited.