### PR TITLE
go to style manager after installing style

### DIFF
--- a/install-usercss/install-usercss.js
+++ b/install-usercss/install-usercss.js
@@ -1,6 +1,6 @@
 /* global $ $create $createLink $$remove showSpinner */// dom.js
 /* global API */// msg.js
-/* global closeCurrentTab deepEqual */// toolbox.js
+/* global deepEqual */// toolbox.js
 /* global messageBox */
 /* global prefs */
 /* global preinit */
@@ -301,17 +301,9 @@ function install(style) {
 
   updateMeta(style);
 
-  if (!liveReload.enabled && !prefs.get('openEditInWindow')) {
-    location.href = '/edit.html?id=' + style.id;
-  } else {
-    API.openEditor({id: style.id});
-    if (!liveReload.enabled) {
-      if (tabId < 0 && history.length > 1) {
-        history.back();
-      } else {
-        closeCurrentTab();
-      }
-    }
+  if (!liveReload.enabled) {
+    sessionStorage.justEditedStyleId = style.id;
+    location.href = '/manage.html';
   }
 }
 


### PR DESCRIPTION
Currently, after we press the install button, a style editor is opened either in the same tab or in a new window, which seems pretty useless to me as 1) we just shown the source code in the installer, 2) editing remote styles is not something we encourage.

This PR goes to the style manager in the same tab. The style entry gets a quick highlight animation. Thoughts?