### PR TITLE
fix/deduplicate/simplify installer html/css/js

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -230,44 +230,6 @@
       </table>
     </template>
 
-    <template data-id="styleSettings">
-      <div>
-        <fieldset class="style-settings can-close-on-esc">
-          <label i18n-text="styleUpdateUrlLabel">
-            <input id="ss-update-url" type="text">
-          </label>
-          <div>
-            <div i18n-text="installPreferSchemeLabel"></div>
-            <label i18n-text-append="installPreferSchemeNone">
-              <input name="ss-scheme" type="radio" value="none">
-            </label>
-            <label i18n-text-append="installPreferSchemeDark">
-              <input name="ss-scheme" type="radio" value="dark">
-            </label>
-            <label i18n-text-append="installPreferSchemeLight">
-              <input name="ss-scheme" type="radio" value="light">
-            </label>
-          </div>
-          <label i18n-text="styleIncludeLabel">
-            <textarea id="ss-inclusions" spellcheck="false"
-                      placeholder="*://site1.com/*&#10;*://site2.com/*"></textarea>
-          </label>
-          <label i18n-text="styleExcludeLabel">
-            <textarea id="ss-exclusions" spellcheck="false"
-                      placeholder="*://site1.com/*&#10;*://site2.com/*"></textarea>
-          </label>
-        </fieldset>
-        <div class="buttons">
-          <button id="ss-save" i18n-text="confirmSave" disabled></button>
-          <label i18n-title="configOnChangeTooltip" i18n-text-append="configOnChange">
-            <input id="config.autosave" type="checkbox">
-            <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
-          </label>
-          <button id="ss-close" i18n-text="confirmClose"></button>
-        </div>
-      </div>
-    </template>
-
     <link href="vendor/codemirror/lib/codemirror.css" rel="stylesheet">
     <link href="vendor/codemirror/addon/dialog/dialog.css" rel="stylesheet">
     <link href="vendor/codemirror/addon/fold/foldgutter.css" rel="stylesheet">

--- a/edit/settings.html
+++ b/edit/settings.html
@@ -1,0 +1,35 @@
+<div>
+  <fieldset class="style-settings can-close-on-esc">
+    <label i18n-text="styleUpdateUrlLabel">
+      <input id="ss-update-url" type="text">
+    </label>
+    <div id="ss-scheme">
+      <div i18n-text="installPreferSchemeLabel"></div>
+      <label i18n-text-append="installPreferSchemeNone">
+        <input name="ss-scheme" type="radio" value="none">
+      </label>
+      <label i18n-text-append="installPreferSchemeDark">
+        <input name="ss-scheme" type="radio" value="dark">
+      </label>
+      <label i18n-text-append="installPreferSchemeLight">
+        <input name="ss-scheme" type="radio" value="light">
+      </label>
+    </div>
+    <label i18n-text="styleIncludeLabel">
+      <textarea id="ss-inclusions" spellcheck="false"
+                placeholder="*://site1.com/*&#10;*://site2.com/*"></textarea>
+    </label>
+    <label i18n-text="styleExcludeLabel">
+      <textarea id="ss-exclusions" spellcheck="false"
+                placeholder="*://site1.com/*&#10;*://site2.com/*"></textarea>
+    </label>
+  </fieldset>
+  <div class="buttons">
+    <button id="ss-save" i18n-text="confirmSave" disabled></button>
+    <label i18n-title="configOnChangeTooltip" i18n-text-append="configOnChange">
+      <input id="config.autosave" type="checkbox">
+      <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
+    </label>
+    <button id="ss-close" i18n-text="confirmClose"></button>
+  </div>
+</div>

--- a/edit/settings.js
+++ b/edit/settings.js
@@ -7,9 +7,10 @@
 /* exported StyleSettings */
 'use strict';
 
-function StyleSettings() {
+async function StyleSettings() {
   const AUTOSAVE_DELAY = 500; // same as config-dialog.js
   const SS_ID = 'styleSettings';
+  await t.fetchTemplate('/edit/settings.html', SS_ID);
   const {style} = editor;
   const ui = t.template[SS_ID].cloneNode(true);
   const elAuto = $('[id="config.autosave"]', ui);

--- a/install-usercss.html
+++ b/install-usercss.html
@@ -11,12 +11,11 @@
   <script src="js/polyfill.js"></script>
   <script src="js/msg.js"></script>
   <script src="js/toolbox.js"></script>
-
-  <script src="install-usercss/preinit.js"></script>
-
   <script src="js/prefs.js"></script>
   <script src="js/dom.js"></script>
   <script src="js/localization.js"></script>
+
+  <script src="install-usercss/preinit.js"></script>
 
   <script src="content/style-injector.js"></script>
   <script src="content/apply.js"></script>
@@ -25,66 +24,59 @@
   <link href="install-usercss/install-usercss.css" rel="stylesheet">
 </head>
 <body id="stylus-install-usercss">
-  <div class="container">
-    <div id="header">
-      <div id="header-content-wrapper">
-        <h1>
-          <span class="meta-name"></span>
-          <small class="meta-version"></small>
-        </h1>
-        <div class="actions">
-          <h2 hidden class="installed" i18n-text="installButtonInstalled"></h2>
-          <button class="install" i18n-text="installButton"></button>
-          <a class="configure-usercss" i18n-title="configureStyle" tabindex="0">
-            <svg class="svg-icon config"><use xlink:href="#svg-icon-config"></use></svg>
-          </a>
-          <p id="live-reload-install-hint" hidden></p>
-          <label class="set-update-url">
-            <input type="checkbox">
-            <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
-            <span i18n-text="installUpdateFromLabel"></span>
-            <p></p>
-          </label>
-          <label class="live-reload">
-            <input type="checkbox">
-            <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
-            <span i18n-text="liveReloadLabel"></span>
-          </label>
-          <label class="set-prefer-scheme">
-            <span i18n-text="installPreferSchemeLabel"></span>
-            <select>
-              <option value="none" i18n-text="installPreferSchemeNone"></option>
-              <option value="dark" i18n-text="installPreferSchemeDark"></option>
-              <option value="light" i18n-text="installPreferSchemeLight"></option>
-            </select>
-          </label>
-          <p hidden class="installed-actions">
-            <a href="manage.html" tabindex="0"><button i18n-text="openManage"></button></a>
-            <a href="edit.html?id=" tabindex="0"><button i18n-text="editStyleLabel"></button></a>
-            <a id="delete" tabindex="0"><button i18n-text="deleteStyleLabel"></button></a>
-          </p>
-        </div>
-        <p class="meta-description"></p>
-        <div>
-          <h3 i18n-text="author"></h3>
-          <span class="meta-author"></span>
-        </div>
-        <div>
-          <h3 i18n-text="license"></h3>
-          <span class="meta-license"></span>
-        </div>
-        <div class="external-link"></div>
-        <div id="applies-to-wrapper">
-          <h3 i18n-text="appliesLabel"></h3>
-          <ul class="applies-to">
-          </ul>
+  <div id="header">
+    <div id="header-contents">
+      <h1 class="w100">
+        <span class="meta-name"></span>
+        <small class="meta-version"></small>
+      </h1>
+      <div id="install-wrapper">
+        <h2 class="install-show" i18n-text="installButtonInstalled"></h2>
+        <button class="install install-hide" i18n-text="installButton"></button>
+        <a class="configure-usercss" i18n-title="configureStyle" tabindex="0">
+          <svg class="svg-icon config"><use xlink:href="#svg-icon-config"></use></svg>
+        </a>
+        <div class="install-show w100-full">
+          <a href="manage.html"><button i18n-text="openManage"></button></a>
+          <a id="edit" href="edit.html?id="><button i18n-text="editStyleLabel"></button></a>
+          <a id="delete" tabindex="0"><button i18n-text="deleteStyleLabel"></button></a>
         </div>
       </div>
-      <div id="header-resizer" i18n-title="headerResizerHint"></div>
+      <div id="ss-scheme" class="install-dim"></div>
+      <div class="set-update-url w100 checkbox-wrapper install-disable">
+        <label>
+          <input type="checkbox">
+          <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
+          <span i18n-text="installUpdateFromLabel"></span>
+        </label>
+        <p></p>
+      </div>
+      <label class="live-reload checkbox-wrapper">
+        <input type="checkbox">
+        <svg class="svg-icon checked"><use xlink:href="#svg-icon-checked"/></svg>
+        <span i18n-text="liveReloadLabel"></span>
+      </label>
+      <div id="live-reload-install-hint" class="w100" hidden></div>
+      <div class="meta-description w100 hide-empty"></div>
+      <div>
+        <h3 i18n-text="author"></h3>
+        <span class="meta-author"></span>
+      </div>
+      <div>
+        <h3 i18n-text="license"></h3>
+        <span class="meta-license"></span>
+      </div>
+      <div class="external-link hide-empty"></div>
+      <div class="w100">
+        <h3 i18n-text="appliesLabel"></h3>
+        <ul class="applies-to">
+        </ul>
+      </div>
     </div>
-    <div class="main">
-      <div class="warnings"></div>
-    </div>
+    <div id="header-resizer" i18n-title="headerResizerHint"></div>
+  </div>
+  <div class="main">
+    <div class="warnings"></div>
   </div>
 
   <svg xmlns="http://www.w3.org/2000/svg" style="display: none !important;">

--- a/install-usercss/install-usercss.css
+++ b/install-usercss/install-usercss.css
@@ -2,6 +2,8 @@ body {
   overflow: hidden;
   margin: 0;
   background: white;
+  display: flex;
+  height: 100vh;
 }
 
 a {
@@ -22,24 +24,28 @@ input:disabled + span {
   color: rgb(128, 128, 128);
 }
 
-.container {
-  display: flex;
-  height: 100vh;
-}
-
 #header,
 .warnings {
   flex: 0 0 var(--header-width);
   box-sizing: border-box;
   padding: 1rem;
   box-shadow: 0 0 50px -18px black;
+  word-break: break-all;
   overflow-wrap: break-word;
   overflow-y: auto;
   z-index: 100;
 }
-
+#header {
+  --child-gap: 1rem;
+}
+#header-contents > :nth-last-child(n + 3) {
+  margin-bottom: var(--child-gap);
+}
 #header.meta-init-error {
   display: none;
+}
+#header-contents ul {
+  margin: 0;
 }
 
 .warnings {
@@ -72,26 +78,47 @@ input:disabled + span {
 
 h1 {
   margin-top: 0;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
 }
-
-h1 small {
+.meta-name {
+  margin-right: .5em;
+}
+.meta-version {
   font-size: 0.6em;
+  white-space: nowrap;
 }
-
 .meta-version::before {
-  content: " v";
+  content: "v";
 }
-
-.actions {
-  margin-bottom: 1em;
+.checkbox-wrapper {
+  padding-left: 16px;
+  position: relative;
+  box-sizing: border-box;
+  display: block;
 }
-
-.actions label {
-  max-width: -moz-fit-content;
-  max-width: fit-content;
+.set-update-url p {
+  word-break: break-all;
+  opacity: .5;
+  margin: .25em 0 0;
+}
+#ss-scheme > label {
+  display: block;
+}
+#install-wrapper {
   display: flex;
   align-items: center;
-  margin: 0.5em 0;
+  flex-wrap: wrap;
+}
+#install-wrapper > :nth-last-child(n + 2) {
+  margin-right: .5rem;
+}
+#live-reload-install-hint {
+  color: darkcyan;
+}
+.w100 {
+  width: 100%;
 }
 
 .install {
@@ -107,7 +134,6 @@ h1 small {
   -webkit-appearance: none;
   -moz-appearance: none;
   border-style: none;
-  margin-bottom: 1ex;
   cursor: pointer;
   box-shadow: inset 0 -1px 0 0 hsl(0, 0%, 24%), inset 0 1px 0 0 hsl(0, 0%, 30%), inset 1px 0 0 0 hsl(0, 0%, 24%);
   transition: color .25s, background-color .25s;
@@ -212,44 +238,25 @@ h1 small {
   filter: hue-rotate(-18deg) brightness(.7) contrast(2);
 }
 
-.install.installed {
-  display: none;
-}
-
-h2.installed.active {
-  display: inline-block;
+h2 {
   font-weight: bold;
-  margin-top: 0;
+  margin: 0;
   color: darkcyan;
 }
-h2.installed.active ~ .configure-usercss svg {
+.installed .configure-usercss svg {
   fill: hsl(180, 100%, 20%);
 }
-h2.installed.active ~ .configure-usercss:hover svg {
+.installed .configure-usercss:hover svg {
   fill: hsl(180, 100%, 30%);
 }
 
-.actions label input {
-  margin: 0 0.5em 0 0;
-  flex: 0 0 auto;
+#header-contents > .hide-empty:empty,
+body:not(.installed) .install-show,
+.installed .install-hide {
+  display: none !important;
 }
-
-.actions label span {
-  min-width: 0;
-}
-
-.set-update-url {
-  flex-wrap: wrap;
-}
-.set-update-url p {
-  word-break: break-all;
+.installed .install-dim {
   opacity: .5;
-  width: 100%;
-  margin: .25em 0 .25em;
-}
-
-label.set-prefer-scheme:not(.unavailable) {
-  padding-left: 0;
 }
 
 .external {
@@ -270,8 +277,8 @@ li {
 
 .main,
 .main .CodeMirror {
-  height: 100% !important;
-  width: 100% !important;
+  height: 100%;
+  width: 100%;
   border: none;
 }
 
@@ -282,28 +289,22 @@ li {
 }
 
 #header:not(.meta-init) > *:not(.lds-spinner),
-#header.meta-init > .lds-spinner {
+.meta-init > .lds-spinner {
   -moz-user-select: none;
   user-select: none;
   pointer-events: none;
   opacity: 0;
 }
 
-#header.meta-init > * {
+.meta-init > * {
   opacity: 1;
   transition: opacity .5s;
   -moz-user-select: auto;
   user-select: auto;
 }
 
-#header.meta-init[data-arrived-fast="true"] > * {
+.meta-init[data-arrived-fast="true"] > * {
   transition-duration: .1s;
-}
-
-label {
-  /* FIXME: why do we want to give all labels a padding? */
-  padding-left: 16px;
-  position: relative;
 }
 
 .lds-spinner {
@@ -316,7 +317,6 @@ label {
 .configure-usercss .svg-icon.config {
   width: 20px;
   height: 20px;
-  margin-top: -3px;
 }
 #message-box.config-dialog {
   width: 0;
@@ -331,117 +331,73 @@ label {
 
 @media (max-width: 850px) {
   body {
-    overflow: hidden;
-  }
-  .container {
     flex-direction: column;
   }
   #header {
-    flex: 0 1 auto;
-    border-right: none;
     border-bottom: 1px dashed #AAA;
-    overflow-x: auto;
-    overflow-y: hidden;
-    padding: 0;
+    min-height: 6rem;
+    max-height: 40vh;
+    resize: vertical;
+    flex: 0 1 auto;
+    --child-gap: .75rem;
   }
   #header:not(.meta-init) {
     min-height: 300px;
   }
-  .main {
-    flex: 1;
-  }
-  #header-content-wrapper {
+  #header-contents {
     display: flex;
     flex-wrap: wrap;
-    padding: .5rem 0 0 1rem;
-    box-sizing: border-box;
-    height: min-content;
-  }
-  #header-content-wrapper > * {
-    flex-grow: 1;
-    margin: 0;
-    padding: 0 1rem .5rem 0;
-    min-width: 0;
-  }
-  #header-content-wrapper > .meta-description + .flex-wrapper {
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    padding: 0;
-  }
-  #header-content-wrapper > .meta-description + .flex-wrapper > * {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    flex-wrap: wrap;
-    white-space: nowrap;
-    padding: 0 1rem .5rem 0;
-    box-sizing: border-box;
-  }
-  .flex-wrapper ul {
-    margin: 0;
-  }
-  #header-content-wrapper > .meta-description {
-    flex-basis: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .actions {
-    display: flex;
-    flex-wrap: wrap;
+    align-content: flex-start;
     align-items: flex-start;
   }
-  .set-update-url p {
+  #header-contents > :not(.w100) {
+    margin-right: 1rem;
+  }
+  #header-contents .set-update-url {
+    display: flex;
     white-space: nowrap;
+    box-sizing: border-box;
+  }
+  .set-update-url p {
+    margin: 0 0 0 1rem;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-  .actions label {
-    min-width: 100px;
-    flex: 1;
-  }
-  .actions label span {
-    white-space: nowrap;
-  }
-  .has-warnings #header {
-    min-height: 4em;
-    max-height: 20%;
-  }
-  .warnings {
-    max-height: 20%;
   }
   .warning:not(:last-child) {
     border-bottom: 1px dashed #b57c7c;
     padding-bottom: 1em;
   }
-  ul.applies-to,
-  .actions label {
-    margin: 0;
-  }
-  #header-content-wrapper > h1 {
-    font-size: 1.75em;
-    display: flex;
-    align-items: baseline;
-  }
-  #header-content-wrapper > h1 > .meta-version {
-    padding-left: 3px;
-  }
-  #header-content-wrapper > h1 > .meta-name {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  #header-content-wrapper > * h3 {
+  #header-contents h3 {
     margin: 0 0 .5rem;
-  }
-  .install {
-    flex-shrink: 0;
-    margin-right: 1em;
   }
   #message-box.config-dialog > div {
     top: auto;
     bottom: 3rem;
+  }
+  h1 {
+    flex-wrap: nowrap;
+  }
+  .meta-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  #ss-scheme > label {
+    display: inline;
+  }
+  .main {
+    height: auto;
+    flex: 1;
+  }
+}
+
+@media (min-width: 850px) {
+  #header {
+    height: 100% !important; /* overrides user resize */
+  }
+  .w100-full {
+    width: 100%;
+    margin-top: var(--child-gap);
   }
 }
 

--- a/install-usercss/preinit.js
+++ b/install-usercss/preinit.js
@@ -1,5 +1,6 @@
 /* global API */// msg.js
 /* global closeCurrentTab download */// toolbox.js
+/* global t */// localization.js
 'use strict';
 
 /* exported preinit */
@@ -89,5 +90,7 @@ const preinit = (() => {
         return {error, sourceCode};
       }
     })(),
+
+    tpl: t.fetchTemplate('/edit/settings.html', 'styleSettings'),
   };
 })();

--- a/js/localization.js
+++ b/js/localization.js
@@ -1,3 +1,4 @@
+/* global download */// toolbox.js
 'use strict';
 
 //#region Exports
@@ -116,6 +117,15 @@ Object.assign(t, {
       bin.appendChild(root.firstChild);
     }
     return bin;
+  },
+
+  async fetchTemplate(url, name) {
+    return t.template[name] || download(url, {responseType: 'document'}).then(doc => {
+      const el = doc.body.firstElementChild;
+      t.NodeList(el.getElementsByTagName('*'));
+      t.template[name] = el;
+      return el;
+    });
   },
 
   sanitizeHtml(root) {

--- a/js/toolbox.js
+++ b/js/toolbox.js
@@ -440,7 +440,7 @@ function download(url, {
   const usoVars = [];
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    const u = new URL(collapseUsoVars(url));
+    const u = new URL(collapseUsoVars(url), location);
     const onTimeout = () => {
       xhr.abort();
       reject(new Error('Timeout fetching ' + u.href));


### PR DESCRIPTION
Turns out our installer UI was partly messed up in compact mode after the recent additions. I've fixed it but in the process had to simplify/rework some parts so I'm opening a PR just in case. There should be no functional changes.

Copied scheme selector from the editor:

type | pic
-|-
full width | ![image](https://user-images.githubusercontent.com/1310400/149671615-78f7e8d9-0b71-413c-873e-ae816344aa70.png)
compact | ![image](https://user-images.githubusercontent.com/1310400/149671246-e81e9d14-896c-442f-ac71-fcb67eba2663.png)

Simplified html/css/js because everything was fine-tuned to a specific set of features, which was inflexible and prone to breaking. For example, many child elements in the header had their own explicitly specified margins/paddings, now there's a single rule. Removed the redundant `container`. Where possible, switched from explicit toggling of elements to a declarative method that we already use for classes like `non-chromium` or `hidden-unless-compact`.