### PR TITLE
autosave in editor

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -342,6 +342,19 @@
     "message": "Disable",
     "description": "Label for the button to disable a style"
   },
+  "draftTitle": {
+    "message": "Draft recovery, created $date$",
+    "placeholders": {
+      "date": {
+        "content": "$1"
+      }
+    },
+    "description": "Title of the modal displayed in the editor when an unsaved draft is found, the $date$ looks like '1 hour ago' in user's current UI language"
+  },
+  "draftAction": {
+    "message": "Choose 'Yes' to load this draft or 'No' to discard it.",
+    "description": "Displayed in the editor after the browser/extension crashed"
+  },
   "dragDropMessage": {
     "message": "Drop your backup file anywhere on this page to import.",
     "description": "Drag'n'drop message"

--- a/background/background.js
+++ b/background/background.js
@@ -1,6 +1,7 @@
 /* global API msg */// msg.js
 /* global addAPI bgReady */// common.js
 /* global createWorker */// worker-util.js
+/* global db */
 /* global prefs */
 /* global styleMan */
 /* global syncMan */
@@ -36,6 +37,11 @@ addAPI(/** @namespace API */ {
       data[key] = val;
     },
   }))(),
+
+  /** @type IDBObjectStore */
+  drafts: new Proxy({}, {
+    get: (_, cmd) => (...args) => db.exec.call('drafts', cmd, ...args),
+  }),
 
   styles: styleMan,
   sync: syncMan,

--- a/background/db-chrome-storage.js
+++ b/background/db-chrome-storage.js
@@ -2,17 +2,15 @@
 'use strict';
 
 /* exported createChromeStorageDB */
-function createChromeStorageDB() {
+function createChromeStorageDB(PREFIX) {
   let INC;
 
-  const PREFIX = 'style-';
-  const METHODS = {
+  return {
 
     delete(id) {
       return chromeLocal.remove(PREFIX + id);
     },
 
-    // FIXME: we don't use this method at all. Should we remove this?
     get(id) {
       return chromeLocal.getValue(PREFIX + id);
     },
@@ -59,8 +57,4 @@ function createChromeStorageDB() {
       }
     }
   }
-
-  return function dbExecChromeStorage(method, ...args) {
-    return METHODS[method](...args);
-  };
 }

--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -106,6 +106,7 @@ const styleMan = (() => {
         // Must be called after the style is deleted from dataMap
         API.usw.revoke(id);
       }
+      API.drafts.delete(id);
       await msg.broadcast({
         method: 'styleDeleted',
         style: {id},

--- a/edit/drafts.js
+++ b/edit/drafts.js
@@ -14,7 +14,7 @@
   const draft = await API.drafts.get(draftId);
   if (draft && draft.isUsercss === editor.isUsercss) {
     const date = makeRelativeDate(draft.date);
-    if (await messageBoxProxy.confirm(t('draftAction'), 'danger pre-line', t('draftTitle', date))) {
+    if (await messageBoxProxy.confirm(t('draftAction'), 'danger', t('draftTitle', date))) {
       await editor.replaceStyle(draft.style, draft);
     } else {
       updateDraft(false);

--- a/edit/drafts.js
+++ b/edit/drafts.js
@@ -25,7 +25,7 @@
     debounce(updateDraft, isDirty ? delay : 0);
   });
 
-  prefs.subscribe('editor.autosaveDelay', (key, val) => {
+  prefs.subscribe('editor.autosaveDraft', (key, val) => {
     delay = clamp(val * 1000 | 0, 1000, 2 ** 32 - 1);
     const t = debounce.timers.get(updateDraft);
     if (t != null) debounce(updateDraft, t ? delay : 0);

--- a/edit/drafts.js
+++ b/edit/drafts.js
@@ -28,7 +28,7 @@
   prefs.subscribe('editor.autosaveDelay', (key, val) => {
     delay = clamp(val * 1000 | 0, 1000, 2 ** 32 - 1);
     const t = debounce.timers.get(updateDraft);
-    if (t != null) debounce(updateDraft, t);
+    if (t != null) debounce(updateDraft, t ? delay : 0);
   }, {runNow: true});
 
   function makeRelativeDate(date) {

--- a/edit/drafts.js
+++ b/edit/drafts.js
@@ -1,0 +1,70 @@
+/* global messageBoxProxy */// dom.js
+/* global API */// msg.js
+/* global clamp debounce */// toolbox.js
+/* global editor */
+/* global prefs */
+/* global t */// localization.js
+'use strict';
+
+(async function AutosaveDrafts() {
+  const NEW = 'new';
+  let delay;
+  let draftId = editor.style.id || NEW;
+
+  const draft = await API.drafts.get(draftId);
+  if (draft && draft.isUsercss === editor.isUsercss) {
+    const date = makeRelativeDate(draft.date);
+    if (await messageBoxProxy.confirm(t('draftAction'), 'danger pre-line', t('draftTitle', date))) {
+      await editor.replaceStyle(draft.style, draft);
+    } else {
+      updateDraft(false);
+    }
+  }
+
+  editor.dirty.onDataChange(isDirty => {
+    debounce(updateDraft, isDirty ? delay : 0);
+  });
+
+  prefs.subscribe('editor.autosaveDelay', (key, val) => {
+    delay = clamp(val * 1000 | 0, 1000, 2 ** 32 - 1);
+    const t = debounce.timers.get(updateDraft);
+    if (t != null) debounce(updateDraft, t);
+  }, {runNow: true});
+
+  function makeRelativeDate(date) {
+    let delta = (Date.now() - date) / 1000;
+    if (delta >= 0 && Intl.RelativeTimeFormat) {
+      for (const [span, unit, frac = 1] of [
+        [60, 'second', 0],
+        [60, 'minute', 0],
+        [24, 'hour'],
+        [7, 'day'],
+        [4, 'week'],
+        [12, 'month'],
+        [1e99, 'year'],
+      ]) {
+        if (delta < span) {
+          return new Intl.RelativeTimeFormat({style: 'short'}).format(-delta.toFixed(frac), unit);
+        }
+        delta /= span;
+      }
+    }
+    return date.toLocaleString();
+  }
+
+  function updateDraft(isDirty = editor.dirty.isDirty()) {
+    const newDraftId = editor.style.id || NEW;
+    if (isDirty) {
+      API.drafts.put({
+        date: Date.now(),
+        id: newDraftId,
+        isUsercss: editor.isUsercss,
+        style: editor.getValue(true),
+        si: editor.makeScrollInfo(),
+      });
+    } else {
+      API.drafts.delete(draftId); // the old id may have been 0 when a new style is saved now
+    }
+    draftId = newDraftId;
+  }
+})();

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -58,6 +58,7 @@ baseInit.ready.then(async () => {
 
   require([
     '/edit/autocomplete',
+    '/edit/drafts',
     '/edit/global-search',
   ]);
 });
@@ -139,16 +140,7 @@ window.on('beforeunload', e => {
     prefs.set('windowPosition', pos);
   }
   sessionStore.windowPos = JSON.stringify(pos || {});
-  sessionStore['editorScrollInfo' + editor.style.id] = JSON.stringify({
-    scrollY: window.scrollY,
-    cms: editor.getEditors().map(cm => /** @namespace EditorScrollInfo */({
-      bookmarks: (cm.state.sublimeBookmarks || []).map(b => b.find()),
-      focus: cm.hasFocus(),
-      height: cm.display.wrapper.style.height.replace('100vh', ''),
-      parentHeight: cm.display.wrapper.parentElement.offsetHeight,
-      sel: cm.isClean() && [cm.doc.sel.ranges, cm.doc.sel.primIndex],
-    })),
-  });
+  sessionStore['editorScrollInfo' + editor.style.id] = JSON.stringify(editor.makeScrollInfo());
   const activeElement = document.activeElement;
   if (activeElement) {
     // blurring triggers 'change' or 'input' event if needed
@@ -193,6 +185,19 @@ window.on('beforeunload', e => {
           cm.state.sublimeBookmarks = si.bookmarks.map(b => cm.markText(b.from, b.to, bmOpts));
         });
       }
+    },
+
+    makeScrollInfo() {
+      return {
+        scrollY: window.scrollY,
+        cms: editor.getEditors().map(cm => /** @namespace EditorScrollInfo */({
+          bookmarks: (cm.state.sublimeBookmarks || []).map(b => b.find()),
+          focus: cm.hasFocus(),
+          height: cm.display.wrapper.style.height.replace('100vh', ''),
+          parentHeight: cm.display.wrapper.parentElement.offsetHeight,
+          sel: [cm.doc.sel.ranges, cm.doc.sel.primIndex],
+        })),
+      };
     },
 
     async save() {

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -477,6 +477,7 @@ function SectionsEditor() {
     keepDirty = false,
     si = editor.scrollInfo,
   } = {}) {
+    editor.ready = false;
     if (replace) {
       sections.forEach(s => s.remove(true));
       sections.length = 0;
@@ -514,6 +515,7 @@ function SectionsEditor() {
     }
     container.style.removeProperty('height');
     setGlobalProgress();
+    editor.ready = true;
   }
 
   /** @param {EditorSection} section */

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -86,15 +86,21 @@ function SectionsEditor() {
         : null;
     },
 
-    async replaceStyle(newStyle) {
+    async replaceStyle(newStyle, draft) {
       const sameCode = styleSectionsEqual(newStyle, getModel());
-      if (!sameCode && !await messageBoxProxy.confirm(t('styleUpdateDiscardChanges'))) {
+      if (!sameCode && !draft && !await messageBoxProxy.confirm(t('styleUpdateDiscardChanges'))) {
         return;
       }
-      dirty.clear();
+      if (!draft) {
+        dirty.clear();
+      }
       // FIXME: avoid recreating all editors?
       if (!sameCode) {
-        await initSections(newStyle.sections, {replace: true});
+        await initSections(newStyle.sections, {
+          keepDirty: draft,
+          replace: true,
+          si: draft && draft.si,
+        });
       }
       editor.useSavedStyle(newStyle);
       updateLivePreview();
@@ -468,14 +474,14 @@ function SectionsEditor() {
   async function initSections(src, {
     focusOn = 0,
     replace = false,
-    keepDirty = false, // used by import
+    keepDirty = false,
+    si = editor.scrollInfo,
   } = {}) {
     if (replace) {
       sections.forEach(s => s.remove(true));
       sections.length = 0;
       container.textContent = '';
     }
-    let si = editor.scrollInfo;
     if (si && si.cms && si.cms.length === src.length) {
       si.scrollY2 = si.scrollY + window.innerHeight;
       container.style.height = si.scrollY2 + 'px';
@@ -503,7 +509,9 @@ function SectionsEditor() {
       if (!keepDirty) dirty.clear();
       if (i === focusOn) sections[i].cm.focus();
     }
-    if (!si) requestAnimationFrame(fitToAvailableSpace);
+    if (!si || si.cms.every(cm => !cm.height)) {
+      requestAnimationFrame(fitToAvailableSpace);
+    }
     container.style.removeProperty('height');
     setGlobalProgress();
   }

--- a/js/dlg/message-box.js
+++ b/js/dlg/message-box.js
@@ -1,4 +1,5 @@
 /* global $ $create animateElement focusAccessibility moveFocus */// dom.js
+/* global clamp */// toolbox.js
 /* global t */// localization.js
 'use strict';
 
@@ -83,10 +84,6 @@ messageBox.show = async ({
   return new Promise(resolve => {
     messageBox._resolve = resolve;
   });
-
-  function clamp(value, min, max) {
-    return Math.min(Math.max(value, min), max);
-  }
 
   function initOwnListeners() {
     let listening = false;

--- a/js/dom-on-load.js
+++ b/js/dom-on-load.js
@@ -1,5 +1,5 @@
 /* global $$ $ $create focusAccessibility getEventKeyName moveFocus */// dom.js
-/* global debounce */// toolbox.js
+/* global clamp debounce */// toolbox.js
 /* global t */// localization.js
 'use strict';
 
@@ -34,7 +34,7 @@
       const key = isSelect ? 'selectedIndex' : 'valueAsNumber';
       const old = el[key];
       const rawVal = old + Math.sign(event.deltaY) * (el.step || 1);
-      el[key] = Math.max(el.min || 0, Math.min(el.max || el.length - 1, rawVal));
+      el[key] = clamp(rawVal, el.min || 0, el.max || el.length - 1);
       if (el[key] !== old) {
         el.dispatchEvent(new Event('change', {bubbles: true}));
       }

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -99,6 +99,7 @@
     'editor.selectByTokens': true,
 
     'editor.appliesToLineWidget': true, // show applies-to line widget on the editor
+    'editor.autosaveDelay': 10, // seconds
     'editor.livePreview': true,
 
     // show CSS colors as clickable colored rectangles

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -99,7 +99,7 @@
     'editor.selectByTokens': true,
 
     'editor.appliesToLineWidget': true, // show applies-to line widget on the editor
-    'editor.autosaveDelay': 10, // seconds
+    'editor.autosaveDraft': 10, // seconds
     'editor.livePreview': true,
 
     // show CSS colors as clickable colored rectangles

--- a/js/toolbox.js
+++ b/js/toolbox.js
@@ -4,6 +4,7 @@
   CHROME_POPUP_BORDER_BUG
   RX_META
   capitalize
+  clamp
   closeCurrentTab
   deepEqual
   download
@@ -131,6 +132,10 @@ if (FIREFOX || OPERA || VIVALDI) {
 // FF57+ supports openerTabId, but not in Android
 // (detecting FF57 by the feature it added, not navigator.ua which may be spoofed in about:config)
 const openerTabIdSupported = (!FIREFOX || window.AbortController) && chrome.windows != null;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
 
 function getOwnTab() {
   return browser.tabs.getCurrent();

--- a/options/options.js
+++ b/options/options.js
@@ -17,6 +17,7 @@
   OPERA
   URLS
   capitalize
+  clamp
   ignoreChromeError
   openURL
 */// toolbox.js
@@ -288,7 +289,7 @@ function enforceInputRange(element) {
     if (type === 'input' && element.checkValidity()) {
       doNotify();
     } else if (type === 'change' && !element.checkValidity()) {
-      element.value = Math.max(min, Math.min(max, Number(element.value)));
+      element.value = clamp(Number(element.value), min, max);
       doNotify();
     }
   };

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -10,6 +10,7 @@
   FIREFOX
   URLS
   capitalize
+  clamp
   getActiveTab
   isEmptyObj
 */// toolbox.js
@@ -66,7 +67,7 @@ function onRuntimeMessage(msg) {
 
 function setPopupWidth(_key, width) {
   document.body.style.width =
-    Math.max(200, Math.min(800, width)) + 'px';
+    clamp(width, 200, 800) + 'px';
 }
 
 function toggleSideBorders(_key, state) {


### PR DESCRIPTION
Fixes #1303.

Unsaved changes in the editor are stored as a draft for this style id.

Saving removes the draft.

Opening the editor for this style will show a prompt:

![image](https://user-images.githubusercontent.com/1310400/150589896-40638e33-df9e-46ad-8988-37693a88a9ca.png)

The timer is `10` seconds, customizable in devtools console: `prefs.set('editor.autosaveDelay', 1)`.
Didn't add it in UI because there's a lot of settings already so I thought I'll implement CodeMirror-related stuff first (#1083).