### PR TITLE
scrollable details + sticky header

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -418,17 +418,15 @@
           <summary><h2 i18n-text="sections"></h2></summary>
           <ol id="toc"></ol>
         </details>
-        <details id="lint" data-pref="editor.lint.expanded" class="hidden-unless-compact ignore-pref-if-compact">
+        <details id="lint" data-pref="editor.lint.expanded" class="ignore-pref-if-compact" hidden>
           <summary>
-            <h2 i18n-text="linterIssues">: <span id="issue-count"></span>
+            <h2><span i18n-text="linterIssues"></span><span id="issue-count"></span>
               <a id="lint-help" class="svg-inline-wrapper intercepts-click" tabindex="0">
                 <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
               </a>
             </h2>
           </summary>
-          <div class="lint-scroll-container">
-            <div class="lint-report-container"></div>
-          </div>
+          <div class="lint-report-container"></div>
         </details>
       </div>
       <div id="header-resizer" i18n-title="headerResizerHint"></div>

--- a/edit/base.js
+++ b/edit/base.js
@@ -6,14 +6,7 @@
 /* global initBeautifyButton */// beautify.js
 /* global prefs */
 /* global t */// localization.js
-/* global
-  FIREFOX
-  debounce
-  getOwnTab
-  sessionStore
-  tryJSONparse
-  tryURL
-*/// toolbox.js
+/* global FIREFOX getOwnTab sessionStore tryJSONparse tryURL */// toolbox.js
 'use strict';
 
 /**
@@ -56,6 +49,13 @@ const editor = {
 
 const baseInit = (() => {
   const domReady = waitForSelector('#sections');
+  const mq = matchMedia('(max-width: 850px)');
+  (mq.onchange = e => {
+    document.documentElement.classList.toggle('compact-layout', e.matches);
+    for (const el of $$('details[data-pref]')) {
+      el.open = e.matches ? false : prefs.get(el.dataset.pref);
+    }
+  })(mq);
 
   return {
     domReady,
@@ -119,45 +119,6 @@ const baseInit = (() => {
     }
   }
 })();
-
-//#endregion
-//#region init layout/resize
-
-baseInit.domReady.then(() => {
-  let headerHeight;
-  detectLayout(true);
-  window.on('resize', () => detectLayout());
-
-  function detectLayout(now) {
-    const compact = window.innerWidth <= 850;
-    if (compact) {
-      document.body.classList.add('compact-layout');
-      if (!editor.isUsercss) {
-        if (now) fixedHeader();
-        else debounce(fixedHeader, 250);
-        window.on('scroll', fixedHeader, {passive: true});
-      }
-    } else {
-      document.body.classList.remove('compact-layout', 'fixed-header');
-      window.off('scroll', fixedHeader);
-    }
-    for (const el of $$('details[data-pref]')) {
-      el.open = compact ? false : prefs.get(el.dataset.pref);
-    }
-  }
-
-  function fixedHeader() {
-    const headerFixed = $('.fixed-header');
-    if (!headerFixed) headerHeight = $('#header').clientHeight;
-    const scrollPoint = headerHeight - 43;
-    if (window.scrollY >= scrollPoint && !headerFixed) {
-      $('body').style.setProperty('--fixed-padding', ` ${headerHeight}px`);
-      $('body').classList.add('fixed-header');
-    } else if (window.scrollY < scrollPoint && headerFixed) {
-      $('body').classList.remove('fixed-header');
-    }
-  }
-});
 
 //#endregion
 //#region init header

--- a/edit/base.js
+++ b/edit/base.js
@@ -1,4 +1,4 @@
-/* global $ $$ $create setupLivePrefs waitForSelector */// dom.js
+/* global $ $$ $create $root setupLivePrefs waitForSelector */// dom.js
 /* global API */// msg.js
 /* global CODEMIRROR_THEMES */
 /* global CodeMirror */
@@ -32,7 +32,7 @@ const editor = {
   cancel: () => location.assign('/manage.html'),
 
   updateClass() {
-    document.documentElement.classList.toggle('is-new-style', !editor.style.id);
+    $root.classList.toggle('is-new-style', !editor.style.id);
   },
 
   updateTitle(isDirty = editor.dirty.isDirty()) {
@@ -49,16 +49,14 @@ const editor = {
 
 const baseInit = (() => {
   const domReady = waitForSelector('#sections');
-  const mq = matchMedia('(max-width: 850px)');
-  (mq.onchange = e => {
-    document.documentElement.classList.toggle('compact-layout', e.matches);
-    for (const el of $$('details[data-pref]')) {
-      el.open = e.matches ? false : prefs.get(el.dataset.pref);
-    }
-  })(mq);
+  const mqCompact = matchMedia('(max-width: 850px)');
+  const toggleCompact = mq => $root.classList.toggle('compact-layout', mq.matches);
+  mqCompact.on('change', toggleCompact);
+  toggleCompact(mqCompact);
 
   return {
     domReady,
+    mqCompact,
     ready: Promise.all([
       domReady,
       loadStyle(),
@@ -94,7 +92,7 @@ const baseInit = (() => {
     editor.style = style;
     editor.updateClass();
     editor.updateTitle(false);
-    document.documentElement.classList.toggle('usercss', editor.isUsercss);
+    $root.classList.add(editor.isUsercss ? 'usercss' : 'sectioned');
     sessionStore.justEditedStyleId = style.id || '';
     // no such style so let's clear the invalid URL parameters
     if (!style.id) history.replaceState({}, '', location.pathname);

--- a/edit/base.js
+++ b/edit/base.js
@@ -1,4 +1,4 @@
-/* global $ $$ $create $root setupLivePrefs waitForSelector */// dom.js
+/* global $ $$ $create setupLivePrefs waitForSelector */// dom.js
 /* global API */// msg.js
 /* global CODEMIRROR_THEMES */
 /* global CodeMirror */
@@ -32,7 +32,7 @@ const editor = {
   cancel: () => location.assign('/manage.html'),
 
   updateClass() {
-    $root.classList.toggle('is-new-style', !editor.style.id);
+    $.rootCL.toggle('is-new-style', !editor.style.id);
   },
 
   updateTitle(isDirty = editor.dirty.isDirty()) {
@@ -50,7 +50,7 @@ const editor = {
 const baseInit = (() => {
   const domReady = waitForSelector('#sections');
   const mqCompact = matchMedia('(max-width: 850px)');
-  const toggleCompact = mq => $root.classList.toggle('compact-layout', mq.matches);
+  const toggleCompact = mq => $.rootCL.toggle('compact-layout', mq.matches);
   mqCompact.on('change', toggleCompact);
   toggleCompact(mqCompact);
 
@@ -92,7 +92,7 @@ const baseInit = (() => {
     editor.style = style;
     editor.updateClass();
     editor.updateTitle(false);
-    $root.classList.add(editor.isUsercss ? 'usercss' : 'sectioned');
+    $.rootCL.add(editor.isUsercss ? 'usercss' : 'sectioned');
     sessionStore.justEditedStyleId = style.id || '';
     // no such style so let's clear the invalid URL parameters
     if (!style.id) history.replaceState({}, '', location.pathname);

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -1093,6 +1093,7 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
     margin-top: 0;
     z-index: 1000;
   }
+  #details-wrapper details[open]:hover,
   #details-wrapper details[open]:focus-within {
     z-index: 1001;
   }
@@ -1118,6 +1119,7 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
     left: 0;
     margin-left: auto;
     margin-right: auto;
+    width: min-content;
   }
   #sections-list[open] > #toc,
   #lint[open] > .lint-report-container {

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -843,12 +843,17 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   border-spacing: 0;
   line-height: 1.0;
   width: 100%;
+  font-size: 85%;
+  cursor: pointer;
 }
 #lint tr td:last-child {
   width: 100%;
 }
 #lint td[role="line"] {
   padding-left: 0.25rem;
+}
+#lint .report {
+  display: flex;
 }
 #lint .empty {
   display: none;
@@ -858,16 +863,12 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   line-height: 16px;
   font-weight: bold;
 }
-#lint .report {
-  font-size: 85%;
-  cursor: pointer;
-}
-.lint-report-container > :not(.empty) ~ :not(.empty) {
+#lint .report:not(.empty) ~ :not(.empty) {
   border-top: 1px dotted rgba(128, 128, 128, .5);
   margin-top: .25em;
   padding-top: .25em;
 }
-#lint .report tr:hover {
+#lint tr:hover {
   background-color: hsla(180, 50%, 36%, .2);
 }
 #lint td {

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -1,6 +1,7 @@
 :root {
   --pad: 1rem;
   --pad05: calc(0.5 * var(--pad));
+  --popup-button-width: 16px;
 }
 
 body {
@@ -1031,22 +1032,27 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   #header:not(.sticky) {
     position: static;
   }
-  #header {
+  #header:not(.sticky) {
     display: block;
+  }
+  #header {
     flex: 0 0 auto;
     height: unset;
     width: 100%;
+    overflow: visible;
     background: #fff;
     border-right: none;
     border-bottom: 1px dashed #AAA;
     padding: var(--pad05) var(--pad05) 0;
   }
   #header.sticky {
+    flex-direction: row;
     box-shadow: 0 0 3rem -.75rem black;
   }
   #header.sticky #basic-info,
   #header.sticky #mozilla-format-buttons,
   #header.sticky .buttons > button,
+  #header.sticky .split-btn-pedal,
   #heading,
   #header-sticker {
     top: 0;
@@ -1054,11 +1060,14 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
     position: absolute;
     visibility: hidden;
   }
+  .popup-window #details-wrapper {
+    margin-right: var(--popup-button-width);
+  }
   h2 {
     display: none;
   }
   #basic-info {
-    margin: 0 16px var(--pad05) 0; /* for popup icon in simple window */
+    margin: 0 var(--popup-button-width) var(--pad05) 0;
     box-sizing: border-box;
     display: flex;
     flex-wrap: wrap;
@@ -1086,14 +1095,35 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
     flex-direction: row;
     margin: .25em 0 var(--pad05);
   }
-  #details-wrapper details[open] {
-    max-height: 10vh;
-  }
   #details-wrapper[data-open^=".."] details {
     max-width: 50%;
   }
   #details-wrapper[data-open^="..."] {
     flex-wrap: wrap;
+  }
+  #details-wrapper details[open] {
+    margin-top: 0;
+    z-index: 1000;
+  }
+  #details-wrapper details[open]:focus-within {
+    z-index: 1001;
+  }
+  #details-wrapper details[open] > summary {
+    position: static;
+    margin-top: 0;
+  }
+  #details-wrapper details[open] > summary + * {
+    position: absolute;
+    overflow-y: auto;
+    max-height: 10vh;
+    background: #fff;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, .3);
+    padding: var(--pad);
+  }
+  #sections-list[open] > #toc,
+  #lint[open] > .lint-report-container {
+    max-width: 50vw;
+    right: 0;
   }
   #options[open],
   #publish[open],

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -1,5 +1,6 @@
 :root {
-  --fixed-padding: unset;
+  --pad: 1rem;
+  --pad05: calc(0.5 * var(--pad));
 }
 
 body {
@@ -70,7 +71,7 @@ html:not(.is-new-style) #heading::after {
 #popup-button:hover {
   filter: drop-shadow(0 0 3px hsl(180, 70%, 50%));
 }
-.usercss body:not(.compact-layout) #popup-button {
+.usercss:not(.compact-layout) #popup-button {
   right: 24px;
 }
 /************ checkbox & select************/
@@ -91,10 +92,10 @@ label {
 #header {
   width: var(--header-width);
   height: 100vh;
-  overflow: auto;
+  overflow: hidden;
   position: fixed;
   top: 0;
-  padding: 1rem;
+  padding-top: var(--pad);
   box-shadow: 0 0 3rem -1.2rem black;
   box-sizing: border-box;
   z-index: 10;
@@ -222,56 +223,61 @@ input:invalid {
   margin-left: 0;
 }
 /* collapsibles */
+#header details {
+  margin-right: var(--header-resizer-width);
+}
+#header details[open] {
+  overflow-y: auto;
+  margin-top: calc(1.5*var(--pad));
+}
+#header details[open] summary {
+  position: absolute;
+  margin-top: calc(-1.5*var(--pad));
+}
 #header summary {
   align-items: center;
-  margin-left: -13px;
+  margin-left: .25em;
   cursor: pointer;
-}
-#header summary + * {
-  padding: .5rem 0;
+  white-space: nowrap;
 }
 #header summary h2 {
   display: inline-block;
   border-bottom: 1px dotted transparent;
-  margin-top: .1em;
-  margin-bottom: .1em;
-  margin-left: -13px;
+  margin: 0 0 0 -13px;
   padding-left: 13px; /* clicking directly on details-marker doesn't set pref so we cover it with h2 */
+  max-width: calc(var(--header-width) - 2*var(--pad));
+  vertical-align: middle;
 }
-
+#header summary h2,
+#header summary h2 > :first-child {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 #header summary:hover h2 {
   border-color: #bbb;
 }
-
 #header summary svg {
   margin-top: -3px;
 }
-
+#header details > :not(summary) {
+  margin: 0 0 0 var(--pad);
+  padding: calc(var(--pad)/4) 0;
+}
 #details-wrapper {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  overflow: hidden;
+  margin-top: var(--pad05);
 }
-
-#header details[open] + details[open] {
-  margin-top: .5rem;
-}
-
 #actions .buttons {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
 }
-
 #actions .buttons > * {
-  margin: 0 .25rem .5rem 0;
-}
-
-#options:not([open]) + #lint h2 {
-  margin-top: 0;
-}
-#lint:not([open]) h2 {
-  margin-bottom: 0;
+  margin: 0 .25rem var(--pad05) 0;
 }
 
 #publish > div > * {
@@ -426,8 +432,6 @@ input:invalid {
 }
 #toc {
   counter-reset: codelabel;
-  margin: 0;
-  padding: .5rem 0;
 }
 #toc li {
   white-space: nowrap;
@@ -829,40 +833,13 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
 
 /************ lint ************/
 #lint {
-  overflow: hidden;
-  margin-left: -1rem;
-  margin-right: -1rem;
-  padding: 0;
-  box-sizing: border-box;
-  display: flex;
-  flex-grow: 1;
-  position: relative;
-}
-#lint > summary {
-  position: relative;
-  margin-left: 0;
-  padding-left: 4px;
-}
-#lint[open]:not(.hidden-unless-compact) {
-  min-height: 102px;
-}
-#lint summary h2 {
-  text-indent: -2px;
-}
-#lint > .lint-scroll-container {
-  margin: 1rem 10px 0;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  overflow-y: auto;
   overflow-x: hidden;
 }
+#lint summary h2 {
+  display: inline-flex;
+}
 #lint table {
-  font-size: 100%;
   border-spacing: 0;
-  margin-bottom: 1rem;
   line-height: 1.0;
   width: 100%;
 }
@@ -878,7 +855,7 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
 #lint table.empty {
   display: none;
 }
-#lint caption {
+#lint caption:not(:empty) {
   text-align: left;
   font-weight: bold;
   padding-bottom: 6px;
@@ -907,6 +884,9 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
 #lint td[role="message"] {
   text-align: left;
   white-space: nowrap;
+}
+#issue-count::before {
+  content: ':\A0';
 }
 #message-box.center.lint-config #message-box-contents {
   text-align: left;
@@ -970,11 +950,6 @@ html:not(.usercss) .usercss-only,
   display: none !important; /* hide during page init */
 }
 
-body:not(.compact-layout) .hidden-unless-compact,
-body.linter-disabled .hidden-unless-compact {
-  display: none !important;
-}
-
 #options:not([open]) + #lint {
   margin-top: 0;
 }
@@ -1021,152 +996,100 @@ body.linter-disabled .hidden-unless-compact {
   margin-left: 0.2rem;
 }
 
+/************ full-width only ************/
+/* TODO: maybe move more rules here so we don't need to reset them in @media(max-width: 850px) */
+@media (min-width: 851px) {
+  #header > :not(#details-wrapper):not(#header-resizer) {
+    margin-left: var(--pad);
+    margin-right: var(--pad);
+  }
+  #publish[open],
+  #header details:not([open]) {
+    flex: 0 0 auto;
+  }
+  #header details[open]:not(:last-child) {
+    margin-bottom: var(--pad05);
+  }
+  #header details:last-child {
+    padding-bottom: var(--pad);
+  }
+}
+
 /************ reponsive layouts ************/
 @media(max-width: 850px) {
-  body {
+  html:not(.usercss) body {
+    height: 100%;
+  }
+  .usercss body {
     display: flex;
     flex-direction: column;
   }
+  .usercss #header {
+    position: inherit;
+  }
   #header {
-    flex: 0 1 auto;
+    display: block;
+    flex: 0 0 auto;
     height: unset;
     width: unset;
-    position: inherit;
+    position: sticky;
+    background: #fff;
     border-right: none;
     border-bottom: 1px dashed #AAA;
-    padding: .5rem 1rem .5rem .5rem;
-  }
-  .fixed-header {
-    --fixed-height: 40px;
-    padding-top: var(--fixed-padding);
-  }
-  .fixed-header #header {
-    min-height: var(--fixed-height);
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    padding: 0;
-    background-color: #fff;
-  }
-  .fixed-header #header > *:not(#details-wrapper),
-  .fixed-header #options {
-    display: none !important;
-  }
-  .fixed-header #details-wrapper {
-    padding-top: calc((var(--fixed-height) - 1.2rem) / 2); /* 1.2 is the normal line height */
-  }
-  #header summary + *,
-  #lint > .lint-scroll-container {
-    margin-left: 1rem;
-    padding: .25rem 0 .5rem;
-  }
-  #header input[type="checkbox"] {
-    vertical-align: middle;
-  }
-  #header details {
-    margin: 0;
+    padding: var(--pad05) var(--pad05) 0;
   }
   #heading,
   h2 {
     display: none;
   }
   #basic-info {
-    margin-bottom: .5rem;
+    margin: 0 16px var(--pad05) 0; /* for popup icon in simple window */
     box-sizing: border-box;
     display: flex;
     flex-wrap: wrap;
   }
+  #basic-info #name,
   #basic-info > *:first-child {
     flex-grow: 1;
   }
   #basic-info > *:not(:last-child) {
     margin-right: 0.8rem;
   }
-  #basic-info #name {
-    flex-grow: 1;
+  #header details > :not(summary) {
+    margin-left: var(--pad05);
   }
-  #options-wrapper {
-    display: flex;
-    flex-wrap: wrap;
-    box-sizing: border-box;
+  #header h2 {
+    font-size: 14px;
+  }
+  #actions {
+    display: inline-block;
   }
   #details-wrapper {
+    display: inline-flex;
+    vertical-align: top;
+    max-width: 100%;
     flex-direction: row;
-    flex-wrap: wrap;
+    margin: .25em 0 var(--pad05);
   }
-  #options[open] {
-    width: 100%;
+  #details-wrapper details[open] {
+    max-height: 10vh;
   }
-  #sections-list[open] {
-    max-height: 102px;
-  }
-  #sections-list[open] #toc {
-    max-height: 60px;
-    overflow-y: auto;
-  }
-  #header details:not(#options) {
+  #details-wrapper[data-open^=".."] details {
     max-width: 50%;
   }
-  .options-column {
-    flex-grow: 1;
-    padding-right: .5rem;
-    box-sizing: border-box;
+  #details-wrapper[data-open^="..."] {
+    flex-wrap: wrap;
   }
-  .options-column > .usercss-only {
-    margin-bottom: 0;
-  }
-  #options-wrapper .options-column:nth-child(2) {
-    margin-top: 0;
-  }
-  #options:not([open]),
+  #options[open],
+  #publish[open],
   #lint:not([open]) {
-    overflow: initial;
-  }
-  #options:not([open]) + #lint:not([open]) {
-    margin-top: 0;
-  }
-  #lint summary {
-    position: static;
-    margin-bottom:  0;
-  }
-  #header summary {
-    margin-left: 0;
-    padding-left: 4px;
-  }
-  #header summary h2 {
-    margin: 0;
-    padding: 0;
-  }
-  .option label {
-    margin: 0;
-  }
-  #options [type="number"] {
-    text-align: left; /* workaround the column flow bug in webkit */
-    padding-left: 0.2rem;
-  }
-  #options #tabSize-label {
-    position: relative;
-    top: 0.2rem;
-  }
-  #lint > .lint-scroll-container {
-    padding-top: 0;
-    margin-right: 0;
-  }
-  #lint {
-    padding: 0;
-    margin: .5rem 0 0;
-  }
-  #lint:not([open]) + #footer {
-    margin: .25em 0 -1em .25em;
+    flex: 0 0 auto;
+    overflow-x: hidden;
   }
   #sections {
-    height: unset !important;
     padding-left: 0;
-    display: flex;
-    flex-direction: column;
-    flex: 1;
   }
+  /* TODO: switch from .single-editor to the global .usercss */
   #sections > :not(.single-editor) {
     margin: 0 .5rem;
     padding: .5rem 0;
@@ -1174,10 +1097,6 @@ body.linter-disabled .hidden-unless-compact {
   .single-editor {
     overflow: hidden;
     flex: 1;
-  }
-  .usercss #options:not([open]) ~ #lint.hidden ~ #footer,
-  .usercss #lint:not([open]) + #footer {
-    margin-top: -.25em;
   }
   #help-popup.big[style="display: block;"],
   #help-popup[style="display: block;"] {

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -1054,17 +1054,11 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   #header.sticky .buttons > button,
   #header.sticky .split-btn-pedal,
   #heading,
-  #header-sticker {
-    top: 0;
-    height: 1px;
-    position: absolute;
-    visibility: hidden;
+  h2 {
+    display: none;
   }
   .popup-window #details-wrapper {
     margin-right: var(--popup-button-width);
-  }
-  h2 {
-    display: none;
   }
   #basic-info {
     margin: 0 var(--popup-button-width) var(--pad05) 0;

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -849,26 +849,29 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
 #lint td[role="line"] {
   padding-left: 0.25rem;
 }
-#lint table:last-child {
-  margin-bottom: 0;
-}
-#lint table.empty {
+#lint .empty {
   display: none;
 }
-#lint caption:not(:empty) {
-  text-align: left;
+#lint .caption {
+  vertical-align: top;
+  line-height: 16px;
   font-weight: bold;
-  padding-bottom: 6px;
 }
-#lint tbody {
+#lint .report {
   font-size: 85%;
   cursor: pointer;
 }
-#lint tr:hover {
+.lint-report-container > :not(.empty) ~ :not(.empty) {
+  border-top: 1px dotted rgba(128, 128, 128, .5);
+  margin-top: .25em;
+  padding-top: .25em;
+}
+#lint .report tr:hover {
   background-color: hsla(180, 50%, 36%, .2);
 }
 #lint td {
   padding: 0;
+  line-height: 16px;
 }
 #lint td[role="severity"] {
   font-size: 0;

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -379,11 +379,11 @@ input:invalid {
   box-shadow: none !important;
   pointer-events: auto !important; /* FF bug */
 }
-.section-editor .section {
+.sectioned .section {
   margin: 0 0.7rem;
   padding: 1rem;
 }
-.section-editor .section:not(:first-child) {
+.sectioned .section:not(:first-child) {
   border-top: 2px solid hsl(0, 0%, 80%);
 }
 .add-section:after {
@@ -419,10 +419,10 @@ input:invalid {
   content: counter(codebox) ": " attr(data-text);
   margin-left: 0.25rem;
 }
-.single-editor .applies-to {
+.usercss .applies-to {
   border-width: 1px 0;
 }
-.single-editor .applies-to > label::before {
+.usercss .applies-to > label::before {
   content: attr(data-index) ":";
   margin-right: 0.25rem;
   font-size: 12px;
@@ -586,7 +586,7 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   padding: 0;
   line-height: var(--input-height);
 }
-.section-editor .applies-to label {
+.sectioned .applies-to label {
   margin-left: -24px;
   position: absolute;
 }
@@ -948,7 +948,7 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   box-shadow: none;
 }
 
-html:not(.usercss) .usercss-only,
+.sectioned .usercss-only,
 .usercss .sectioned-only {
   display: none !important; /* hide during page init */
 }
@@ -1020,28 +1020,40 @@ html:not(.usercss) .usercss-only,
 
 /************ reponsive layouts ************/
 @media(max-width: 850px) {
-  html:not(.usercss) body {
+  .sectioned body {
     height: 100%;
   }
   .usercss body {
     display: flex;
     flex-direction: column;
   }
-  .usercss #header {
-    position: inherit;
+  .usercss #header,
+  #header:not(.sticky) {
+    position: static;
   }
   #header {
     display: block;
     flex: 0 0 auto;
     height: unset;
-    width: unset;
-    position: sticky;
+    width: 100%;
     background: #fff;
     border-right: none;
     border-bottom: 1px dashed #AAA;
     padding: var(--pad05) var(--pad05) 0;
   }
+  #header.sticky {
+    box-shadow: 0 0 3rem -.75rem black;
+  }
+  #header.sticky #basic-info,
+  #header.sticky #mozilla-format-buttons,
+  #header.sticky .buttons > button,
   #heading,
+  #header-sticker {
+    top: 0;
+    height: 1px;
+    position: absolute;
+    visibility: hidden;
+  }
   h2 {
     display: none;
   }
@@ -1092,7 +1104,6 @@ html:not(.usercss) .usercss-only,
   #sections {
     padding-left: 0;
   }
-  /* TODO: switch from .single-editor to the global .usercss */
   #sections > :not(.single-editor) {
     margin: 0 .5rem;
     padding: .5rem 0;

--- a/edit/edit.css
+++ b/edit/edit.css
@@ -1,5 +1,5 @@
 :root {
-  --pad: 1rem;
+  --pad: 1rem; /* Edge padding for modals/blocks/whatnot. TODO: reuse it in more places */
   --pad05: calc(0.5 * var(--pad));
   --popup-button-width: 16px;
 }
@@ -1095,12 +1095,6 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
     flex-direction: row;
     margin: .25em 0 var(--pad05);
   }
-  #details-wrapper[data-open^=".."] details {
-    max-width: 50%;
-  }
-  #details-wrapper[data-open^="..."] {
-    flex-wrap: wrap;
-  }
   #details-wrapper details[open] {
     margin-top: 0;
     z-index: 1000;
@@ -1114,11 +1108,22 @@ body:not(.find-open) [data-match-highlight-count="1"] .CodeMirror-selection-high
   }
   #details-wrapper details[open] > summary + * {
     position: absolute;
-    overflow-y: auto;
-    max-height: 10vh;
+    overflow: hidden auto;
+    max-height: var(--max-height, 10vh);
     background: #fff;
     box-shadow: 0 6px 20px rgba(0, 0, 0, .3);
     padding: var(--pad);
+    margin-top: var(--pad05);
+  }
+  @media (max-height: 500px) {
+    #details-wrapper {
+      --max-height: 50px;
+    }
+  }
+  #sections-list[open] > #toc {
+    left: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
   #sections-list[open] > #toc,
   #lint[open] > .lint-report-container {

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -39,19 +39,6 @@ baseInit.ready.then(async () => {
   new MutationObserver(() => elSec.open && editor.updateToc())
     .observe(elSec, {attributes: true, attributeFilter: ['open']});
 
-  // Auto-update `data-open` attribute to the number of open details
-  {
-    const wrapper = $('#details-wrapper');
-    const details = $$('details', wrapper);
-    const ds = wrapper.dataset;
-    const update = () => {
-      ds.open = '.'.repeat(details.reduce((res, el) => res + (el.open ? 1 : 0), 0));
-    };
-    for (const el of details) {
-      new MutationObserver(update).observe(el, {attributes: true, attributeFilter: ['open']});
-    }
-  }
-
   $('#toc').onclick = e =>
     editor.jumpToEditor([...$('#toc').children].indexOf(e.target));
   $('#keyMap-help').onclick = () =>
@@ -75,7 +62,8 @@ baseInit.ready.then(async () => {
   const {isUsercss} = editor;
   const el = $create('#header-sticker');
   const scroller = isUsercss ? $('.CodeMirror-scroll') : document.body;
-  const xo = new IntersectionObserver(onScrolled, {root: isUsercss ? scroller : document});
+  const xoRoot = isUsercss ? scroller : undefined;
+  const xo = new IntersectionObserver(onScrolled, {root: xoRoot});
   scroller.appendChild(el);
   onCompactToggled(baseInit.mqCompact);
   baseInit.mqCompact.on('change', onCompactToggled);
@@ -92,9 +80,9 @@ baseInit.ready.then(async () => {
     }
   }
   /** @param {IntersectionObserverEntry[]} entries */
-  function onScrolled([e]) {
+  function onScrolled(entries) {
     const h = $('#header');
-    const sticky = !e.isIntersecting;
+    const sticky = !entries.pop().isIntersecting;
     if (!isUsercss) scroller.style.paddingTop = sticky ? h.offsetHeight + 'px' : '';
     h.classList.toggle('sticky', sticky);
   }

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -60,7 +60,14 @@ baseInit.ready.then(async () => {
 }).then(() => {
   // Set up mini-header on scroll
   const {isUsercss} = editor;
-  const el = $create('#header-sticker');
+  const el = $create({
+    style: `
+      top: 0;
+      height: 1px;
+      position: absolute;
+      visibility: hidden;
+    `.replace(/;/g, '!important;'),
+  });
   const scroller = isUsercss ? $('.CodeMirror-scroll') : document.body;
   const xoRoot = isUsercss ? scroller : undefined;
   const xo = new IntersectionObserver(onScrolled, {root: xoRoot});

--- a/edit/edit.js
+++ b/edit/edit.js
@@ -1,4 +1,4 @@
-/* global $ $create messageBoxProxy waitForSheet */// dom.js
+/* global $$ $ $create messageBoxProxy waitForSheet */// dom.js
 /* global API msg */// msg.js
 /* global CodeMirror */
 /* global SectionsEditor */
@@ -42,6 +42,19 @@ baseInit.ready.then(async () => {
   // and we also toggle `open` directly in other places e.g. in detectLayout()
   new MutationObserver(() => elSec.open && editor.updateToc())
     .observe(elSec, {attributes: true, attributeFilter: ['open']});
+
+  // Auto-update `data-open` attribute to the number of open details
+  {
+    const wrapper = $('#details-wrapper');
+    const details = $$('details', wrapper);
+    const ds = wrapper.dataset;
+    const update = () => {
+      ds.open = '.'.repeat(details.reduce((res, el) => res + (el.open ? 1 : 0), 0));
+    };
+    for (const el of details) {
+      new MutationObserver(update).observe(el, {attributes: true, attributeFilter: ['open']});
+    }
+  }
 
   $('#toc').onclick = e =>
     editor.jumpToEditor([...$('#toc').children].indexOf(e.target));

--- a/edit/embedded-popup.js
+++ b/edit/embedded-popup.js
@@ -1,4 +1,4 @@
-/* global $ $create $remove getEventKeyName */// dom.js
+/* global $ $create $remove $root getEventKeyName */// dom.js
 /* global CodeMirror */
 /* global baseInit */// base.js
 /* global prefs */
@@ -20,7 +20,7 @@
     title: t('optionsCustomizePopup') + '\n' + POPUP_HOTKEY,
     onclick: embedPopup,
   });
-  document.documentElement.appendChild(btn);
+  $root.appendChild(btn);
   baseInit.domReady.then(() => {
     document.body.appendChild(btn);
     // Adding a dummy command to show in keymap help popup

--- a/edit/embedded-popup.js
+++ b/edit/embedded-popup.js
@@ -21,6 +21,7 @@
     onclick: embedPopup,
   });
   $root.appendChild(btn);
+  $root.classList.add('popup-window');
   baseInit.domReady.then(() => {
     document.body.appendChild(btn);
     // Adding a dummy command to show in keymap help popup

--- a/edit/embedded-popup.js
+++ b/edit/embedded-popup.js
@@ -1,4 +1,4 @@
-/* global $ $create $remove $root getEventKeyName */// dom.js
+/* global $ $create $remove getEventKeyName */// dom.js
 /* global CodeMirror */
 /* global baseInit */// base.js
 /* global prefs */
@@ -20,8 +20,8 @@
     title: t('optionsCustomizePopup') + '\n' + POPUP_HOTKEY,
     onclick: embedPopup,
   });
-  $root.appendChild(btn);
-  $root.classList.add('popup-window');
+  $.root.appendChild(btn);
+  $.rootCL.add('popup-window');
   baseInit.domReady.then(() => {
     document.body.appendChild(btn);
     // Adding a dummy command to show in keymap help popup

--- a/edit/global-search.js
+++ b/edit/global-search.js
@@ -1,4 +1,4 @@
-/* global $ $$ $create $remove $root focusAccessibility toggleDataset */// dom.js
+/* global $ $$ $create $remove focusAccessibility toggleDataset */// dom.js
 /* global CodeMirror */
 /* global chromeLocal */// storage-util.js
 /* global colorMimicry */
@@ -588,7 +588,7 @@
       input: colorMimicry($('input:not(:disabled)'), {bg: 'backgroundColor'}),
       icon: colorMimicry($$('svg.info')[1], {fill: 'fill'}),
     };
-    $root.appendChild(
+    $.root.appendChild(
       $(DIALOG_STYLE_SELECTOR) ||
       $create('style' + DIALOG_STYLE_SELECTOR)
     ).textContent = `

--- a/edit/global-search.js
+++ b/edit/global-search.js
@@ -1,4 +1,4 @@
-/* global $ $$ $create $remove focusAccessibility toggleDataset */// dom.js
+/* global $ $$ $create $remove $root focusAccessibility toggleDataset */// dom.js
 /* global CodeMirror */
 /* global chromeLocal */// storage-util.js
 /* global colorMimicry */
@@ -54,7 +54,7 @@
 
     undoHistory: [],
 
-    searchInApplies: !document.documentElement.classList.contains('usercss'),
+    searchInApplies: !editor.isUsercss,
   };
 
   //endregion
@@ -588,7 +588,7 @@
       input: colorMimicry($('input:not(:disabled)'), {bg: 'backgroundColor'}),
       icon: colorMimicry($$('svg.info')[1], {fill: 'fill'}),
     };
-    document.documentElement.appendChild(
+    $root.appendChild(
       $(DIALOG_STYLE_SELECTOR) ||
       $create('style' + DIALOG_STYLE_SELECTOR)
     ).textContent = `

--- a/edit/linter-manager.js
+++ b/edit/linter-manager.js
@@ -312,7 +312,7 @@ linterMan.DEFAULTS = {
   function updateCount() {
     const issueCount = Array.from(tables.values())
       .reduce((sum, table) => sum + table.trs.length, 0);
-    $('#lint').classList.toggle('hidden-unless-compact', issueCount === 0);
+    $('#lint').hidden = !issueCount;
     $('#issue-count').textContent = issueCount;
   }
 

--- a/edit/linter-manager.js
+++ b/edit/linter-manager.js
@@ -328,16 +328,12 @@ linterMan.DEFAULTS = {
   }
 
   function createTable(cm) {
-    const caption = $create('td.caption');
-    const tbody = $create('tbody.report');
-    const table = $create('table',
-      $create('tr', [
-        caption,
-        $create('td', tbody),
-      ]));
+    const caption = $create('.caption');
+    const table = $create('table');
+    const report = $create('.report', [caption, table]);
     const trs = [];
     return {
-      element: table,
+      element: report,
       trs,
       updateAnnotations,
       updateCaption,
@@ -357,20 +353,20 @@ linterMan.DEFAULTS = {
         } else {
           tr = createTr();
           trs.push(tr);
-          tbody.append(tr.element);
+          table.appendChild(tr.element);
         }
         tr.update(anno);
         i++;
       }
       if (i === 0) {
         trs.length = 0;
-        tbody.textContent = '';
+        table.textContent = '';
       } else {
         while (trs.length > i) {
           trs.pop().element.remove();
         }
       }
-      table.classList.toggle('empty', trs.length === 0);
+      report.classList.toggle('empty', !trs.length);
 
       function *getAnnotations() {
         for (const line of lines.filter(Boolean)) {

--- a/edit/linter-manager.js
+++ b/edit/linter-manager.js
@@ -328,9 +328,13 @@ linterMan.DEFAULTS = {
   }
 
   function createTable(cm) {
-    const caption = $create('caption');
-    const tbody = $create('tbody');
-    const table = $create('table', [caption, tbody]);
+    const caption = $create('td.caption');
+    const tbody = $create('tbody.report');
+    const table = $create('table',
+      $create('tr', [
+        caption,
+        $create('td', tbody),
+      ]));
     const trs = [];
     return {
       element: table,
@@ -340,7 +344,7 @@ linterMan.DEFAULTS = {
     };
 
     function updateCaption() {
-      caption.textContent = editor.getEditorTitle(cm);
+      Object.assign(caption, editor.getEditorTitle(cm));
     }
 
     function updateAnnotations(lines) {

--- a/edit/linter-manager.js
+++ b/edit/linter-manager.js
@@ -344,7 +344,8 @@ linterMan.DEFAULTS = {
     };
 
     function updateCaption() {
-      Object.assign(caption, editor.getEditorTitle(cm));
+      const t = editor.getEditorTitle(cm);
+      Object.assign(caption, typeof t == 'string' ? {textContent: t} : t);
     }
 
     function updateAnnotations(lines) {

--- a/edit/moz-section-widget.js
+++ b/edit/moz-section-widget.js
@@ -1,4 +1,4 @@
-/* global $ $create messageBoxProxy */// dom.js
+/* global $ $create $root messageBoxProxy */// dom.js
 /* global CodeMirror */
 /* global MozSectionFinder */
 /* global colorMimicry */
@@ -218,7 +218,7 @@ function MozSectionWidget(cm, finder = MozSectionFinder(cm)) {
         transition: none;
       }
     `;
-    document.documentElement.appendChild(actualStyle);
+    $root.appendChild(actualStyle);
   }
 
   /**

--- a/edit/moz-section-widget.js
+++ b/edit/moz-section-widget.js
@@ -1,4 +1,4 @@
-/* global $ $create $root messageBoxProxy */// dom.js
+/* global $ $create messageBoxProxy */// dom.js
 /* global CodeMirror */
 /* global MozSectionFinder */
 /* global colorMimicry */
@@ -218,7 +218,7 @@ function MozSectionWidget(cm, finder = MozSectionFinder(cm)) {
         transition: none;
       }
     `;
-    $root.appendChild(actualStyle);
+    $.root.appendChild(actualStyle);
   }
 
   /**

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -1,4 +1,4 @@
-/* global $ $create $remove $root messageBoxProxy */// dom.js
+/* global $ $create $remove messageBoxProxy */// dom.js
 /* global API */// msg.js
 /* global CodeMirror */
 /* global RX_META debounce */// toolbox.js
@@ -396,7 +396,7 @@ function SectionsEditor() {
     }
 
     function lockPageUI(locked) {
-      $root.style.pointerEvents = locked ? 'none' : '';
+      $.root.style.pointerEvents = locked ? 'none' : '';
       if (popup.codebox) {
         popup.classList.toggle('ready', locked ? false : !popup.codebox.isBlank());
         popup.codebox.options.readOnly = locked;

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -1,4 +1,4 @@
-/* global $ $create $remove messageBoxProxy */// dom.js
+/* global $ $create $remove $root messageBoxProxy */// dom.js
 /* global API */// msg.js
 /* global CodeMirror */
 /* global RX_META debounce */// toolbox.js
@@ -25,7 +25,6 @@ function SectionsEditor() {
   updateMeta();
   rerouteHotkeys.toggle(true); // enabled initially because we don't always focus a CodeMirror
   editor.livePreview.init();
-  container.classList.add('section-editor');
   $('#to-mozilla').on('click', showMozillaFormat);
   $('#to-mozilla-help').on('click', showToMozillaHelp);
   $('#from-mozilla').on('click', () => showMozillaFormatImport());
@@ -397,7 +396,7 @@ function SectionsEditor() {
     }
 
     function lockPageUI(locked) {
-      document.documentElement.style.pointerEvents = locked ? 'none' : '';
+      $root.style.pointerEvents = locked ? 'none' : '';
       if (popup.codebox) {
         popup.classList.toggle('ready', locked ? false : !popup.codebox.isBlank());
         popup.codebox.options.readOnly = locked;

--- a/edit/sections-editor.js
+++ b/edit/sections-editor.js
@@ -46,8 +46,11 @@ function SectionsEditor() {
     },
 
     getEditorTitle(cm) {
-      const index = editor.getEditors().indexOf(cm);
-      return `${t('sectionCode')} ${index + 1}`;
+      const index = editor.getEditors().indexOf(cm) + 1;
+      return {
+        textContent: `#${index}`,
+        title: `${t('sectionCode')} ${index}`,
+      };
     },
 
     getValue(asObject) {

--- a/edit/util.js
+++ b/edit/util.js
@@ -1,4 +1,4 @@
-/* global $ $create $root getEventKeyName messageBoxProxy moveFocus */// dom.js
+/* global $ $create getEventKeyName messageBoxProxy moveFocus */// dom.js
 /* global CodeMirror */
 /* global editor */
 /* global prefs */
@@ -195,7 +195,7 @@ function showCodeMirrorPopup(title, html, options) {
   }, options));
   cm.focus();
 
-  $root.style.pointerEvents = 'none';
+  $.root.style.pointerEvents = 'none';
   popup.style.pointerEvents = 'auto';
 
   const onKeyDown = event => {
@@ -210,7 +210,7 @@ function showCodeMirrorPopup(title, html, options) {
 
   window.on('closeHelp', () => {
     window.off('keydown', onKeyDown, true);
-    $root.style.removeProperty('pointer-events');
+    $.root.style.removeProperty('pointer-events');
     cm = popup.codebox = null;
   }, {once: true});
 

--- a/edit/util.js
+++ b/edit/util.js
@@ -1,4 +1,4 @@
-/* global $ $create getEventKeyName messageBoxProxy moveFocus */// dom.js
+/* global $ $create $root getEventKeyName messageBoxProxy moveFocus */// dom.js
 /* global CodeMirror */
 /* global editor */
 /* global prefs */
@@ -195,7 +195,7 @@ function showCodeMirrorPopup(title, html, options) {
   }, options));
   cm.focus();
 
-  document.documentElement.style.pointerEvents = 'none';
+  $root.style.pointerEvents = 'none';
   popup.style.pointerEvents = 'auto';
 
   const onKeyDown = event => {
@@ -210,7 +210,7 @@ function showCodeMirrorPopup(title, html, options) {
 
   window.on('closeHelp', () => {
     window.off('keydown', onKeyDown, true);
-    document.documentElement.style.removeProperty('pointer-events');
+    $root.style.removeProperty('pointer-events');
     cm = popup.codebox = null;
   }, {once: true});
 

--- a/global.css
+++ b/global.css
@@ -320,6 +320,7 @@ body.resizing-v > * {
 
 .split-btn {
   position: relative;
+  white-space: nowrap;
 }
 .split-btn-pedal {
   margin-left: -1px !important;

--- a/global.css
+++ b/global.css
@@ -277,13 +277,15 @@ input[type="number"][data-focused-via-click]:focus {
 /* header resizer */
 :root {
   --header-width: 280px;
+  --header-resizer-width: 8px;
 }
 #header-resizer {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  width: 6px;
+  width: var(--header-resizer-width);
+  box-sizing: border-box;
   cursor: e-resize;
   border-width: 0 1px;
   border-style: solid;

--- a/js/dom.js
+++ b/js/dom.js
@@ -27,6 +27,8 @@ Object.assign(EventTarget.prototype, {
 
 //#region Exports
 
+const $root = document.documentElement;
+
 // Makes the focus outline appear on keyboard tabbing, but not on mouse clicks.
 const focusAccessibility = {
   // last event's focusedViaClick
@@ -474,10 +476,9 @@ const dom = {};
   const lazyScripts = [
     '/js/dom-on-load',
   ];
-  const elHtml = document.documentElement;
-  if (!UA.windows) elHtml.classList.add('non-windows');
+  if (!UA.windows) $root.classList.add('non-windows');
   // set language for a) CSS :lang pseudo and b) hyphenation
-  elHtml.setAttribute('lang', chrome.i18n.getUILanguage());
+  $root.setAttribute('lang', chrome.i18n.getUILanguage());
   // set up header width resizer
   const HW = 'headerWidth.';
   const HWprefId = HW + location.pathname.match(/^.(\w*)/)[1];
@@ -489,7 +490,7 @@ const dom = {};
         // If this is a small window on a big monitor the user can maximize it later
         const max = (innerWidth < 850 ? screen.availWidth : innerWidth) / 3;
         width = Math.round(Math.max(200, Math.min(max, Number(width) || 0)));
-        elHtml.style.setProperty('--header-width', width + 'px');
+        $root.style.setProperty('--header-width', width + 'px');
         return width;
       },
     });

--- a/js/dom.js
+++ b/js/dom.js
@@ -27,7 +27,8 @@ Object.assign(EventTarget.prototype, {
 
 //#region Exports
 
-const $root = document.documentElement;
+$.root = document.documentElement;
+$.rootCL = $.root.classList;
 
 // Makes the focus outline appear on keyboard tabbing, but not on mouse clicks.
 const focusAccessibility = {
@@ -476,9 +477,9 @@ const dom = {};
   const lazyScripts = [
     '/js/dom-on-load',
   ];
-  if (!UA.windows) $root.classList.add('non-windows');
+  if (!UA.windows) $.rootCL.add('non-windows');
   // set language for a) CSS :lang pseudo and b) hyphenation
-  $root.setAttribute('lang', chrome.i18n.getUILanguage());
+  $.root.setAttribute('lang', chrome.i18n.getUILanguage());
   // set up header width resizer
   const HW = 'headerWidth.';
   const HWprefId = HW + location.pathname.match(/^.(\w*)/)[1];
@@ -490,7 +491,7 @@ const dom = {};
         // If this is a small window on a big monitor the user can maximize it later
         const max = (innerWidth < 850 ? screen.availWidth : innerWidth) / 3;
         width = Math.round(Math.max(200, Math.min(max, Number(width) || 0)));
-        $root.style.setProperty('--header-width', width + 'px');
+        $.root.style.setProperty('--header-width', width + 'px');
         return width;
       },
     });

--- a/js/dom.js
+++ b/js/dom.js
@@ -294,8 +294,8 @@ function scrollElementIntoView(element, {invalidMarginRatio = 0} = {}) {
   const windowHeight = window.innerHeight;
   if (top < Math.max(parentTop, windowHeight * invalidMarginRatio) ||
       top > Math.min(parentBottom, windowHeight) - height - windowHeight * invalidMarginRatio) {
-    const scroller = element.closest('.scroller');
-    scroller.scrollBy(0, top - (scroller ? scroller.clientHeight : windowHeight) / 2 + height);
+    const scroller = element.closest('.scroller') || window;
+    scroller.scrollBy(0, top - (scroller.clientHeight || windowHeight) / 2 + height);
   }
 }
 

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -10,6 +10,7 @@
   $
   $$
   $create
+  $root
   animateElement
   setupLivePrefs
   waitForSelector
@@ -36,7 +37,7 @@ Object.assign(newUI, {
   ids: Object.keys(newUI),
   prefKeyForId: id => `manage.newUI.${id}`.replace(/\.enabled$/, ''),
   renderClass: () => {
-    const cl = document.documentElement.classList;
+    const cl = $root.classList;
     cl.toggle('newUI', newUI.enabled);
     cl.toggle('oldUI', !newUI.enabled);
   },
@@ -128,7 +129,7 @@ function onRuntimeMessage(msg) {
 
 async function toggleEmbeddedOptions(state) {
   const el = $('#stylus-embedded-options') ||
-    state && document.documentElement.appendChild($create('iframe', {
+    state && $root.appendChild($create('iframe', {
       id: 'stylus-embedded-options',
       src: '/options.html',
     }));

--- a/manage/manage.js
+++ b/manage/manage.js
@@ -10,7 +10,6 @@
   $
   $$
   $create
-  $root
   animateElement
   setupLivePrefs
   waitForSelector
@@ -37,9 +36,8 @@ Object.assign(newUI, {
   ids: Object.keys(newUI),
   prefKeyForId: id => `manage.newUI.${id}`.replace(/\.enabled$/, ''),
   renderClass: () => {
-    const cl = $root.classList;
-    cl.toggle('newUI', newUI.enabled);
-    cl.toggle('oldUI', !newUI.enabled);
+    $.rootCL.toggle('newUI', newUI.enabled);
+    $.rootCL.toggle('oldUI', !newUI.enabled);
   },
 });
 // ...read the actual values
@@ -129,7 +127,7 @@ function onRuntimeMessage(msg) {
 
 async function toggleEmbeddedOptions(state) {
   const el = $('#stylus-embedded-options') ||
-    state && $root.appendChild($create('iframe', {
+    state && $.root.appendChild($create('iframe', {
       id: 'stylus-embedded-options',
       src: '/options.html',
     }));

--- a/manage/sorter.js
+++ b/manage/sorter.js
@@ -1,4 +1,4 @@
-/* global $ $create messageBoxProxy onDOMready */// dom.js
+/* global $ $create $root messageBoxProxy onDOMready */// dom.js
 /* global installed */// manage.js
 /* global prefs */
 /* global t */// localization.js
@@ -172,11 +172,11 @@ const sorter = (() => {
 
   function updateColumnCount() {
     let newValue = 1;
-    for (let el = document.documentElement.lastElementChild;
+    for (let el = $root.lastElementChild;
          el.localName === 'style';
          el = el.previousElementSibling) {
       if (el.textContent.includes('--columns:')) {
-        newValue = Math.max(1, getComputedStyle(document.documentElement).getPropertyValue('--columns') | 0);
+        newValue = Math.max(1, getComputedStyle($root).getPropertyValue('--columns') | 0);
         break;
       }
     }

--- a/manage/sorter.js
+++ b/manage/sorter.js
@@ -1,4 +1,4 @@
-/* global $ $create $root messageBoxProxy onDOMready */// dom.js
+/* global $ $create messageBoxProxy onDOMready */// dom.js
 /* global installed */// manage.js
 /* global prefs */
 /* global t */// localization.js
@@ -172,11 +172,11 @@ const sorter = (() => {
 
   function updateColumnCount() {
     let newValue = 1;
-    for (let el = $root.lastElementChild;
+    for (let el = $.root.lastElementChild;
          el.localName === 'style';
          el = el.previousElementSibling) {
       if (el.textContent.includes('--columns:')) {
-        newValue = Math.max(1, getComputedStyle($root).getPropertyValue('--columns') | 0);
+        newValue = Math.max(1, getComputedStyle($.root).getPropertyValue('--columns') | 0);
         break;
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Stylus",
   "version": "1.5.22",
-  "minimum_chrome_version": "56",
+  "minimum_chrome_version": "55",
   "description": "__MSG_description__",
   "homepage_url": "https://add0n.com/stylus.html",
   "manifest_version": 2,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Stylus",
   "version": "1.5.22",
-  "minimum_chrome_version": "55",
+  "minimum_chrome_version": "56",
   "description": "__MSG_description__",
   "homepage_url": "https://add0n.com/stylus.html",
   "manifest_version": 2,

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,4 +1,4 @@
-/* global $ $$ $create $root setupLivePrefs */// dom.js
+/* global $ $$ $create setupLivePrefs */// dom.js
 /* global ABOUT_BLANK getStyleDataMerged preinit */// preinit.js
 /* global API msg */// msg.js
 /* global Events */
@@ -38,7 +38,7 @@ preinit.then(({frames, styles, url}) => {
 msg.onExtension(onRuntimeMessage);
 
 prefs.subscribe('popup.stylesFirst', (key, stylesFirst) => {
-  $root.classList.toggle('styles-last', !stylesFirst);
+  $.rootCL.toggle('styles-last', !stylesFirst);
 }, {runNow: true});
 if (CHROME_POPUP_BORDER_BUG) {
   prefs.subscribe('popup.borders', toggleSideBorders, {runNow: true});
@@ -70,7 +70,7 @@ function setPopupWidth(_key, width) {
 
 function toggleSideBorders(_key, state) {
   // runs before <body> is parsed
-  const style = $root.style;
+  const style = $.root.style;
   if (state) {
     style.cssText +=
       'border-left: 2px solid white !important;' +

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,4 +1,4 @@
-/* global $ $$ $create setupLivePrefs */// dom.js
+/* global $ $$ $create $root setupLivePrefs */// dom.js
 /* global ABOUT_BLANK getStyleDataMerged preinit */// preinit.js
 /* global API msg */// msg.js
 /* global Events */
@@ -38,7 +38,7 @@ preinit.then(({frames, styles, url}) => {
 msg.onExtension(onRuntimeMessage);
 
 prefs.subscribe('popup.stylesFirst', (key, stylesFirst) => {
-  document.documentElement.classList.toggle('styles-last', !stylesFirst);
+  $root.classList.toggle('styles-last', !stylesFirst);
 }, {runNow: true});
 if (CHROME_POPUP_BORDER_BUG) {
   prefs.subscribe('popup.borders', toggleSideBorders, {runNow: true});
@@ -70,7 +70,7 @@ function setPopupWidth(_key, width) {
 
 function toggleSideBorders(_key, state) {
   // runs before <body> is parsed
-  const style = document.documentElement.style;
+  const style = $root.style;
   if (state) {
     style.cssText +=
       'border-left: 2px solid white !important;' +


### PR DESCRIPTION
Solves a long-standing problem with styles that have many sections so the list pushes the lint report out of view. It was also inconvenient that the header was scrollable so the Save button became invisible, and the scrollbar was awkwardly positioned to the right of the resizer grip.

Now only the details are scrollable. Their scrollbars touch the grip which looks kinda neat, although I doubt if it's ok when there's no scrollbar and the contents touches the grip e.g. in the lint report?

~I've switched to `position: sticky`, which allowed to simplify JS listeners and CSS. It's implemented in Chrome 56, so I've bumped our minimum_chrome_version, previously 55.~ One day we may even get rid of this explicit `compact-mode` class toggling and just use `@media` queries.

The sticky headers in usercss/sectioned editors have identical layout now.

The report's caption is shortened to `#N` and inlined, with a tooltip:
![image](https://user-images.githubusercontent.com/1310400/152586057-10c943b3-0a75-443a-acaa-ce0903e90af5.png)

* Compact mode, wide:

  * Sectioned:

    ![image](https://user-images.githubusercontent.com/1310400/152583616-3fc661ec-c2a9-40b9-9908-8c895cdd54be.png)

  * UserCSS

    ![image](https://user-images.githubusercontent.com/1310400/152583883-556158d6-3e47-4010-98bf-bc01c3013ed2.png)

    ![image](https://user-images.githubusercontent.com/1310400/152584048-36bf240c-ea01-4d17-84bf-bfaa549bb7af.png)

* Narrow:

  ![image](https://user-images.githubusercontent.com/1310400/152583654-36f0d1c1-5683-4621-a9c2-1397b9be9081.png)
