### PR TITLE
expose style name

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1085,6 +1085,12 @@
     "message": "Exposes the top site domain in each iframe.\nEnables writing iframe-specific CSS like this:\nhtml[stylus-iframe$$=\"twitter.com\"] h1 { display:none }",
     "description": "Add attribute to iframe; make sure to include the double $$ in the css example, or the `$=` will be omitted in the displayed text."
   },
+  "optionsAdvancedExposeStyleName": {
+    "message": "Expose style name"
+  },
+  "optionsAdvancedExposeStyleNameNote": {
+    "message": "Exposes the style name in the page to facilitate debugging of styles in devtools. Please reload the tab(s) to apply the new setting."
+  },
   "optionsAdvancedNewStyleAsUsercss": {
     "message": "Write new style as usercss"
   },

--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -184,7 +184,8 @@ const styleMan = (() => {
           },
         };
       }
-      const {exposeStyleName} = prefs.__values;
+      // TODO: enable in FF when it supports sourceURL comment in style elements (also options.html)
+      const {exposeStyleName} = CHROME && prefs.__values;
       const sender = CHROME && this && this.sender || {};
       if (sender.frameId === 0) {
         /* Chrome hides text frament from location.href of the page e.g. #:~:text=foo

--- a/background/style-manager.js
+++ b/background/style-manager.js
@@ -184,6 +184,7 @@ const styleMan = (() => {
           },
         };
       }
+      const {exposeStyleName} = prefs.__values;
       const sender = CHROME && this && this.sender || {};
       if (sender.frameId === 0) {
         /* Chrome hides text frament from location.href of the page e.g. #:~:text=foo
@@ -202,9 +203,9 @@ const styleMan = (() => {
       } else if (cache.maybeMatch.size) {
         buildCache(cache, url, Array.from(cache.maybeMatch, id2data).filter(Boolean));
       }
-      return id
-        ? cache.sections[id] ? {[id]: cache.sections[id]} : {}
-        : Object.assign({cfg: {order}}, cache.sections);
+      return Object.assign({cfg: {exposeStyleName, order}},
+        id ? mapObj(cache.sections, null, [id])
+          : cache.sections);
     },
 
     /** @returns {Promise<StyleObj>} */
@@ -429,7 +430,7 @@ const styleMan = (() => {
       const code = getAppliedCode(createMatchQuery(url), style);
       if (code) {
         updated.add(url);
-        cache.sections[id] = {id, code};
+        buildCacheEntry(cache, style, code);
       } else {
         excluded.add(url);
         delete cache.sections[id];
@@ -703,11 +704,18 @@ const styleMan = (() => {
     for (const {style, appliesTo, preview} of styleList) {
       const code = getAppliedCode(query, preview || style);
       if (code) {
-        const id = style.id;
-        cache.sections[id] = {id, code};
+        buildCacheEntry(cache, style, code);
         appliesTo.add(url);
       }
     }
+  }
+
+  function buildCacheEntry(cache, style, code = style.code) {
+    cache.sections[style.id] = {
+      code,
+      id: style.id,
+      name: style.customName || style.name,
+    };
   }
 
   /** @returns {StyleObj[]} */

--- a/background/style-via-webrequest.js
+++ b/background/style-via-webrequest.js
@@ -1,5 +1,5 @@
 /* global API */// msg.js
-/* global CHROME ignoreChromeError */// toolbox.js
+/* global CHROME URLS ignoreChromeError */// toolbox.js
 /* global prefs */
 'use strict';
 
@@ -48,6 +48,12 @@
     }
     if (CHROME && !off) {
       chrome.webNavigation.onCommitted.addListener(injectData, {url: [{urlPrefix: 'http'}]});
+    }
+    if (CHROME) {
+      chrome.webRequest.onBeforeRequest.addListener(openNamedStyle, {
+        urls: [URLS.ownOrigin + '*.user.css'],
+        types: ['main_frame'],
+      }, ['blocking']);
     }
     state.csp = csp;
     state.off = off;
@@ -144,6 +150,12 @@
         URL.revokeObjectURL(blobUrlPrefix + data.blobId);
       }
     }
+  }
+
+  /** @param {chrome.webRequest.WebRequestBodyDetails} req */
+  function openNamedStyle(req) {
+    chrome.tabs.update(req.tabId, {url: 'edit.html?id=' + req.url.split('#')[1]});
+    return {cancel: true};
   }
 
   function req2key(req) {

--- a/background/style-via-webrequest.js
+++ b/background/style-via-webrequest.js
@@ -51,7 +51,7 @@
     }
     if (CHROME) {
       chrome.webRequest.onBeforeRequest.addListener(openNamedStyle, {
-        urls: [URLS.ownOrigin + '*.user.css'],
+        urls: [URLS.ownOrigin + 'virtual/*.css'],
         types: ['main_frame'],
       }, ['blocking']);
     }

--- a/content/apply.js
+++ b/content/apply.js
@@ -105,7 +105,6 @@
       if (styles.cfg) {
         isDisabled = styles.cfg.disableAll;
         Object.assign(order, styles.cfg.order);
-        delete styles.cfg;
       }
       hasStyles = !isDisabled;
       if (hasStyles) {
@@ -181,7 +180,6 @@
         if (!hasStyles && isDisabled || matchUrl === request.url) break;
         matchUrl = request.url;
         API.styles.getSectionsByUrl(matchUrl).then(sections => {
-          delete sections.cfg;
           hasStyles = true;
           styleInjector.replace(sections);
         });

--- a/content/style-injector.js
+++ b/content/style-injector.js
@@ -150,7 +150,7 @@ window.StyleInjector = window.INJECTED === 1 ? window.StyleInjector : ({
     if (exposeStyleName && name) {
       el.dataset.name = name;
       name = encodeURIComponent(name.replace(/[#%/@:']/g, toSafeChar));
-      code += `\n/*# sourceURL=${chrome.runtime.getURL('')}${name}.user.css#${id} */`;
+      code += `\n/*# sourceURL=${chrome.runtime.getURL('')}virtual/${name}.css#${id} */`;
     }
     el.type = 'text/css';
     // SVG className is not a string, but an instance of SVGAnimatedString

--- a/js/prefs.js
+++ b/js/prefs.js
@@ -24,6 +24,7 @@
     'show-badge': true,             // display text on popup menu icon
     'disableAll': false,            // boss key
     'exposeIframes': false,         // Add 'stylus-iframe' attribute to HTML element in all iframes
+    'exposeStyleName': false,       // Add style name to the style for better devtools experience
     'newStyleAsUsercss': false,     // create new style in usercss format
     'styleViaXhr': false,           // early style injection to avoid FOUC
     'patchCsp': false,              // add data: and popular image hosting sites to strict CSP

--- a/options.html
+++ b/options.html
@@ -269,7 +269,7 @@
               <span></span>
             </span>
           </label>
-          <label>
+          <label class="chromium-only">
             <span i18n-text="optionsAdvancedExposeStyleName">
               <a i18n-title="optionsAdvancedExposeStyleNameNote"
                  data-cmd="note" class="svg-inline-wrapper" tabindex="0">

--- a/options.html
+++ b/options.html
@@ -269,6 +269,18 @@
               <span></span>
             </span>
           </label>
+          <label>
+            <span i18n-text="optionsAdvancedExposeStyleName">
+              <a i18n-title="optionsAdvancedExposeStyleNameNote"
+                 data-cmd="note" class="svg-inline-wrapper" tabindex="0">
+                <svg class="svg-icon info"><use xlink:href="#svg-icon-help"/></svg>
+              </a>
+            </span>
+            <span class="onoffswitch">
+              <input type="checkbox" id="exposeStyleName" class="slider">
+              <span></span>
+            </span>
+          </label>
           <label class="chromium-only">
             <span i18n-text="optionsAdvancedContextDelete"></span>
             <span class="onoffswitch">

--- a/options/options.css
+++ b/options/options.css
@@ -105,6 +105,11 @@ a:hover .svg-icon,
 .chromium-only.chrome-no-popup-border {
   display: none;
 }
+label.chromium-only > :first-child::after {
+  content: '(Chrome)';
+  color: #888;
+  margin-left: .5ex;
+}
 
 .block {
   display: flex;
@@ -228,7 +233,7 @@ input[type="color"] {
   position: relative;
 }
 [data-cmd="note"] {
-  padding: .5em 1em .5em 0;
+  padding: .5em 0 .5em 0;
   cursor: pointer;
 }
 .update-in-progress [data-cmd="check-updates"] {


### PR DESCRIPTION
This is only for Chrome because FF's devtools doesn't support sourceURL comment in style elements.

Previously, clicking the `<style>` link in the Styles inspector would select this element in the DOM tree, which was inconvenient and almost useless.

Now, when the `expose style name` option is enabled, the actual style name is shown:

![image](https://user-images.githubusercontent.com/1310400/153257157-ba42dde9-4803-4fff-9d8d-09dd53a272ba.png)

Clicking this link focuses this rule in the devtools source editor:

![image](https://user-images.githubusercontent.com/1310400/153257723-b7dfca91-08ce-4494-b190-f2f6275de5b0.png)

The option is disabled by default because names can be used for tracking/fingerprinting, arguably.

![image](https://user-images.githubusercontent.com/1310400/153329023-070dc3e9-9d14-4187-84e1-470703c8fcef.png)

We can also right-click the devtools editor tab and pick `Open in new tab` to open this style in our editor:

![image](https://user-images.githubusercontent.com/1310400/153258026-7bee2265-b22d-4eaf-9150-0b592f8d8278.png)
