### PR TITLE
Dark arrows for input number in Firefox

### DIFF
--- a/global-dark.css
+++ b/global-dark.css
@@ -150,6 +150,9 @@
   }
   @supports (-moz-appearance: none) {
     /* Workarounds for FF bugs/quirks */
+    input {
+      color-scheme: dark;
+    }
     textarea {
       border: 1px solid var(--c65);
     }

--- a/options/options.css
+++ b/options/options.css
@@ -188,8 +188,23 @@ input[type=number] {
 }
 
 input[type="color"] {
-  box-sizing: border-box;
-  height: 2em;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 0;
+  margin: 4px 0 0 0;
+  border: 1px solid var(--c65);
+  height: var(--input-height);
+  cursor: pointer;
+}
+input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+input[type="color"]::-moz-color-swatch {
+  border: none;
+}
+input[type="color"]::-webkit-color-swatch {
+  border: none;
 }
 
 input[type=time] {


### PR DESCRIPTION
Dark arrows for input numbers in Firefox when using dark mode