### PR TITLE
prevent CodeMirror from disappearing by setting a min-height (#1624)

### DIFF
--- a/edit/edit.css
+++ b/edit/edit.css
@@ -459,6 +459,7 @@ label {
 .section .CodeMirror {
   margin-bottom: .5em;
   box-sizing: border-box;
+  min-height: 20px;
 }
 /* deleted section */
 .deleted-section {


### PR DESCRIPTION
sets the codemirror editor min-height to 20px, as someway, somehow it can end up with a height of `1px`, making it essentially completely invisible

shouldn't break codemirror resizing - it seems to have a fixed minimum of 21px