### PR TITLE
Fix: making the cursor visible when editing "applies-to"

### DIFF
--- a/edit/edit.css
+++ b/edit/edit.css
@@ -568,6 +568,7 @@ i,
 }
 .applies-to input {
   border-color: var(--c85);
+  caret-color: auto;
 }
 .applies-to .select-wrapper {
   margin-right: .5em;


### PR DESCRIPTION
codemirror.css line 69 contains:

    .cm-fat-cursor { caret-color: transparent; }

This, however, makes the cursor invisible in the `.applies-to` widget. Oops! This commit here fixes that bug.

How to reproduce: set the keymap to "Vim", which should make the editor cursor fat.