### PR TITLE
remove node-fetch devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "html-webpack-plugin": "^5.6.3",
     "jszip": "^3.10.1",
     "mini-css-extract-plugin": "^2.9.2",
-    "node-fetch": "^2.7.0",
     "postcss": "^8.4.49",
     "postcss-calc": "^10.0.2",
     "postcss-loader": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
       mini-css-extract-plugin:
         specifier: ^2.9.2
         version: 2.9.2(webpack@5.97.1)
-      node-fetch:
-        specifier: ^2.7.0
-        version: 2.7.0
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -2210,15 +2207,6 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -3056,9 +3044,6 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   transformation-matrix-js@2.7.6:
     resolution: {integrity: sha512-1CxDIZmCQ3vA0GGnkdMQqxUXVm3xXAFmglPYRS1hr37LzSg22TC7QAWOT38OmdUvMEs/rqcnkFoAsqvzdiluDg==}
     deprecated: Package no longer supported. Contact support@npmjs.com for more info.
@@ -3129,9 +3114,6 @@ packages:
   webext-launch-web-auth-flow@0.1.2:
     resolution: {integrity: sha512-NMsUvCp969Yd6gczY9Q5Q+mrmzPkPcsdwvowXSVk4ZnNulCB3Cdfd3noMd/xp+GOjhKKFxMVRkRrxvx3CVUb3w==}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webpack-bundle-analyzer@4.10.2:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
     engines: {node: '>= 10.13.0'}
@@ -3171,9 +3153,6 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -5456,10 +5435,6 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-releases@2.0.19: {}
 
   nomnom@1.8.1:
@@ -6371,8 +6346,6 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tr46@0.0.3: {}
-
   transformation-matrix-js@2.7.6: {}
 
   tslib@2.8.1: {}
@@ -6424,8 +6397,6 @@ snapshots:
       graceful-fs: 4.2.11
 
   webext-launch-web-auth-flow@0.1.2: {}
-
-  webidl-conversions@3.0.1: {}
 
   webpack-bundle-analyzer@4.10.2:
     dependencies:
@@ -6503,11 +6474,6 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@1.3.1:
     dependencies:

--- a/tools/chrome-api-no-cb.js
+++ b/tools/chrome-api-no-cb.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const manifest = require('../src/manifest.json');
-const fetch = require('node-fetch');
 
 (async () => {
   manifest.permissions.push('extension', 'i18n', 'runtime');


### PR DESCRIPTION
Was looking through the package.json, noticed node-fetch. The package.json specifies `engines.node` to be `>=20.6.0`, which only includes Node versions supporting the native `fetch` implementation.