### PR TITLE
Allow to opt-in to domains when excluded via glob

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -420,6 +420,12 @@
   "excludeStyleByUrlLabel": {
     "message": "Exclude the current URL"
   },
+  "includeStyleByDomainLabel": {
+    "message": "Include the current domain"
+  },
+  "includeStyleByUrlLabel": {
+    "message": "Include the current URL"
+  },
   "exportLabel": {
     "message": "Export",
     "description": "Label for the button to export a style (editor) or all styles (style manager)"

--- a/src/background/style-manager/matcher.js
+++ b/src/background/style-manager/matcher.js
@@ -46,9 +46,6 @@ function urlMatchExclusion(e) {
 
 export function urlMatchStyle(query, style) {
   let ovr;
-  if ((ovr = style.exclusions) && ovr.some(urlMatchExclusion, query)) {
-    return 'excluded';
-  }
   if (!style.enabled) {
     return 'disabled';
   }
@@ -57,6 +54,9 @@ export function urlMatchStyle(query, style) {
   }
   if ((ovr = style.inclusions) && ovr.some(urlMatchExclusion, query)) {
     return 'included';
+  }
+  if ((ovr = style.exclusions) && ovr.some(urlMatchExclusion, query)) {
+    return 'excluded';
   }
   return true;
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -117,6 +117,8 @@
       <main>
         <label data-exclude="domain" i18n="+excludeStyleByDomainLabel"><input type="checkbox"></label>
         <label data-exclude="url" i18n="+excludeStyleByUrlLabel"><input type="checkbox"></label>
+        <label data-include="domain" i18n="+includeStyleByDomainLabel"><input type="checkbox"></label>
+        <label data-include="url" i18n="+includeStyleByUrlLabel"><input type="checkbox"></label>
       </main>
       <main class="delete">
         <span i18n="deleteStyleConfirm"></span>

--- a/src/popup/events.js
+++ b/src/popup/events.js
@@ -7,6 +7,7 @@ import * as hotkeys from './hotkeys';
 
 const menu = $id('menu');
 const menuExclusions = [];
+const menuInclusions = [];
 
 export function configure(event, entry) {
   if (!this.target) {
@@ -140,6 +141,16 @@ function menuInit() {
     input.onchange = () => {
       el.classList.toggle('enabled', input.checked);
       API.styles.toggleOverride(menu.styleId, rule, false, input.checked);
+    };
+  }
+  for (const el of $$('[data-include]')) {
+    const input = el.$('input');
+    const rule = u.origin +
+      (el.dataset.include === 'domain' ? '/*' : u.pathname.replace(/\*/g, '\\*'));
+    menuInclusions.push({el, input, rule});
+    input.onchange = () => {
+      el.classList.toggle('enabled', input.checked);
+      API.styles.toggleOverride(menu.styleId, rule, true, input.checked);
     };
   }
 }


### PR DESCRIPTION
This allows wildcarding excluded all domains for a stylesheet (like global dark mode enable), & then opting in per-domain when I need it.

Related: #1892

Basically just prioritize matching includes over excludes. I don't think it's backwards compatible.