### PR TITLE
fix(popup): guard against null/undefined in initPort and popup init

### DIFF
--- a/src/js/port.js
+++ b/src/js/port.js
@@ -96,7 +96,7 @@ export function createPortExec(getTarget, {lock, once} = {}, target) {
       target = getWorkerPort(getTarget, console.error);
     } else if (!target) {
       target = typeof getTarget === 'function' ? getTarget() : getTarget;
-      if (target.then) target = await target;
+      if (target?.then) target = await target;
     }
     if (target instanceof MessagePort) {
       port = target;

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -28,6 +28,7 @@ let prevHeight;
 
 (async function init(data, port) {
   data ??= (__.MV3 ? prefs.clientData : await prefs.clientData)[kPopup] || {};
+  if (!data.tab || !data.frames) return;
   initPopup(data);
   showStyles(data);
   initHotkeys(data);


### PR DESCRIPTION
Fixes #2090

## Problem

When the service worker isn't registered or the database is corrupted, the popup encounters unhandled errors:

1. `TypeError: Cannot read properties of null (reading 'then')` in `initPort` (`src/js/port.js`) — `getTarget()` can resolve to `null`, and the code unconditionally accesses `.then` on the result.
2. `TypeError: Cannot read properties of undefined (reading 'id')` in `initPopup` — `data.tab` is undefined when popup data is incomplete.
3. `TypeError: Cannot read properties of undefined (reading 'length')` in `showStyles` — `data.frames` is undefined.

## Fix

- **`src/js/port.js`**: Use optional chaining (`target?.then`) to safely check if the target is a thenable before awaiting it.
- **`src/popup/index.js`**: Early return from `init()` if `data.tab` or `data.frames` is missing, preventing downstream errors when popup data is incomplete.

## Testing

These are defensive null checks for an edge case that occurs when the browser doesn't register the extension's service worker or the database is corrupted. The fix prevents the unhandled errors from surfacing to users.