### PR TITLE
fix: guard against WebKit runtime API differences

### DIFF
--- a/src/background/icon-manager.js
+++ b/src/background/icon-manager.js
@@ -32,12 +32,23 @@ let hasCanvas = FIREFOX_ANDROID ? false : null;
 if (browserAction) {
   bgInit.push(initIcons);
   if (browserSidebar) {
-    if (__.MV3) // receiving a wake-up event, gonna unregister in subscribe() if not enabled
-      toggleListener(browserAction.onClicked, true, openPopupInSidebar);
-    subscribe('popup.sidePanel', (key, val) => {
-      browserAction.setPopup({popup: val ? '' : 'popup.html'});
-      toggleListener(browserAction.onClicked, val, openPopupInSidebar);
-    }, true);
+    // Some runtimes (e.g. WebKit-based browsers) expose a partial toolbar/action
+    // API that throws "unable to find toolbar item" when the button lives in an
+    // overflow menu. Guard so a broken action API can't abort background init.
+    try {
+      if (__.MV3) // receiving a wake-up event, gonna unregister in subscribe() if not enabled
+        toggleListener(browserAction.onClicked, true, openPopupInSidebar);
+      subscribe('popup.sidePanel', (key, val) => {
+        try {
+          browserAction.setPopup({popup: val ? '' : 'popup.html'});
+          toggleListener(browserAction.onClicked, val, openPopupInSidebar);
+        } catch (err) {
+          __.DEBUGLOG('browserAction.setPopup failed', err);
+        }
+      }, true);
+    } catch (err) {
+      __.DEBUGLOG('browserAction sidebar init failed', err);
+    }
   }
 }
 

--- a/src/background/usercss-manager.js
+++ b/src/background/usercss-manager.js
@@ -85,7 +85,9 @@ export async function buildMeta(style, sourceCode) {
         ? err.args.map(e => e.length === 1 ? JSON.stringify(e) : e).join(', ')
         : err.args;
       const msg = t(`meta_${(err.code)}`, args);
-      if (msg) err.message = msg;
+      // Fall back to a readable message if the locale string is missing (e.g.
+      // i18n not fully initialized), instead of surfacing a bare 'meta_NN'.
+      err.message = msg || `${err.code}${args ? `: ${args}` : ''}`;
       err.index += match.index;
     }
     throw err;

--- a/src/js/msg-init.js
+++ b/src/js/msg-init.js
@@ -56,7 +56,10 @@ if (__.MV3) {
   }
 } else if (!__.IS_BG) {
   apiHandler.apply = async (fn, thisObj, args) => {
-    bg ??= await browser.runtime.getBackgroundPage().catch(() => {}) || false;
+    // WebKit (Orion) can return undefined instead of a Promise here, so guard
+    // the .catch and fall back to messaging the background instead of throwing.
+    bg ??= await Promise.resolve(browser.runtime.getBackgroundPage?.())
+      .catch(() => {}) || false;
     const exec = bg && (bg[k_msgExec] || await bg[k_busy])
       ? invokeAPI
       : apiSendProxy;

--- a/src/js/port.js
+++ b/src/js/port.js
@@ -7,8 +7,14 @@ const PATH = location.pathname;
 const TTL = 5 * 60e3; // TODO: add a configurable option?
 const navLocks = navigator.locks;
 const willAutoClose = __.ENTRY === 'worker' || __.ENTRY === 'offscreen';
+// WebKit (Safari/Orion) masks as Chrome but reports the Apple vendor; its
+// SharedWorker is unreliable in an extension context, so fall back to a plain
+// Worker there. WorkerNavigator has no `vendor` (→ '' → false), which is fine
+// since getWorkerPort only runs in a document context. Chrome ('Google Inc.')
+// and Firefox ('') keep using SharedWorker.
+const WEBKIT = typeof navigator === 'object' && /Apple/.test(navigator.vendor || '');
 // SW can't nest workers, https://crbug.com/40772041
-const SharedWorker = __.ENTRY !== 'sw' && global.SharedWorker;
+const SharedWorker = __.ENTRY !== 'sw' && !WEBKIT && global.SharedWorker;
 const kWorker = '_worker';
 let numJobs = 0;
 let lastBusy = 0;


### PR DESCRIPTION
## What

Four small, independent defensive guards so Stylus degrades gracefully on WebKit-based runtimes (Safari, and Chromium-emulating browsers like Orion) where a few extension APIs behave differently from Chrome/Firefox. Each is a no-op on Chrome and Firefox.

## Changes (one commit each)

- **SharedWorker → Worker fallback** (`port.js`): WebKit reports the Apple vendor while masking as Chrome, and its `SharedWorker` is unreliable in an extension context. Guarded behind a vendor check so those runtimes use the existing plain-`Worker` fallback path that's already there for Chrome Android.
- **`getBackgroundPage` guard** (`msg-init.js`): on WebKit `browser.runtime.getBackgroundPage()` can return `undefined` instead of a Promise, so `.catch` on it throws and breaks every popup API call. Wrapped in `Promise.resolve(...)` + optional chaining so it falls back to messaging the background.
- **Toolbar action guard** (`icon-manager.js`): some runtimes expose a partial `action`/`browserAction` API that throws ("unable to find toolbar item") when the button is in an overflow menu, aborting background init. Wrapped the sidebar wiring in try/catch.
- **usercss meta i18n fallback** (`usercss-manager.js`): surface a readable `code: args` message instead of a bare `meta_NN` key when a locale string is missing.

## Why

Running Stylus in WebKit-emulated-extension environments currently fails early on these calls (worker never initializes, popup API calls throw, background init aborts). These guards keep the existing behavior intact on Chrome/Firefox while letting non-Chrome runtimes fall back instead of throwing.

## Testing

Chrome and Firefox builds compile and behave unchanged. Verified the guards resolve the toolbar/popup/worker-init failures on a WebKit runtime (Orion).

## Scope / honesty note

These are runtime-robustness guards only. They do **not** claim full WebKit support — e.g. `@preprocessor stylus` compilation of large themes still hits a JavaScriptCore recursion limit inside the third-party `stylus-lang` bundle, which is out of scope here. Happy to adjust the vendor detection or split the commits further if you'd prefer.