### PR TITLE
Prevent stale style toggles from creating blank records

### DIFF
--- a/src/background/style-manager/index.js
+++ b/src/background/style-manager/index.js
@@ -401,7 +401,7 @@ export async function setOrder(value) {
 
 /** @returns {Promise<void>} */
 export async function toggle(id, enabled) {
-  const style = styleMap.get(id) || {};
+  const style = styleMap.get(id);
   if (!style)
     return 0;
   style.enabled = !!enabled;


### PR DESCRIPTION
## Summary

- Return `0` when a toggle targets a style that is no longer in `styleMap`.
- Prevent stale Manager actions from persisting and syncing blank style records.

## Root cause

The `styleMap` refactor retained an empty-object fallback, making the missing-style guard unreachable.

Closes #2194.

## Validation

- `pnpm run-p test build-chrome-mv3`
- `pnpm build-firefox`
- `pnpm build-mv2`
